### PR TITLE
support a /json/urls/{key} query to provide loaded details

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ omit =
   *migrations/*,
   *settings*,
   *tests/*,
+  lib/*,
+  lib64/*,
   *urls.py,
   *core/wsgi.py,
   gunicorn.conf.py,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Apprise API was designed to easily fit into existing (and new) eco-systems that 
 [![Docker Pulls](https://img.shields.io/docker/pulls/caronc/apprise.svg?style=flat-square)](https://hub.docker.com/r/caronc/apprise)
 
 ## Screenshots
-There is a small built-in *Configuration Manager* that can be accesed using `/cfg/{KEY}`:<br/>
+There is a small built-in *Configuration Manager* that can be optionally accessed through your web browser accessible via `/cfg/{KEY}`:<br/>
 ![Screenshot of GUI - Using Keys](https://raw.githubusercontent.com/caronc/apprise-api/master/Screenshot-1.png)<br/>
 
 Below is a screenshot of how you can set either a series of URL's to your `{KEY}`, or set your YAML and/or TEXT configuration below.
@@ -47,18 +47,39 @@ docker-compose up
 
 ## API Details
 
-| Path         | Description |
-|------------- | ----------- |
-| `/add/{KEY}` | Saves Apprise Configuration (or set of URLs) to the persistent store.<br/>*Parameters*<br/>:small_red_triangle: **urls**: Used to define one or more Apprise URL(s). Use a comma and/or space to separate one URL from the next.<br/>:small_red_triangle: **config**: Provide the contents of either a YAML or TEXT based Apprise configuration.<br/>:small_red_triangle: **format**: This field is only required if you've specified the _config_ parameter. Used to tell the server which of the supported (Apprise) configuration types you are passing. Valid options are _text_ and _yaml_.
-| `/del/{KEY}` | Removes Apprise Configuration from the persistent store.
-| `/get/{KEY}` | Returns the Apprise Configuration from the persistent store.  This can be directly used with the *Apprise CLI* and/or the *AppriseConfig()* object ([see here for details](https://github.com/caronc/apprise/wiki/config)).
-| `/notify/{KEY}` | Sends a notification based on the Apprise Configuration associated with the specified *{KEY}*.<br/>*Parameters*<br/>:small_red_triangle: **body**: Your message body. This is the *only* required field.<br/>:small_red_triangle: **title**: Optionally define a title to go along with the *body*.<br/>:small_red_triangle: **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `error`. If no *type* is specified then `info` is the default value used.<br/>:small_red_triangle: **tag**: Optionally notify only those tagged accordingly.
-| `/notify/` | Similar to the `notify` API identified above except this one sends a stateless notification and requires no reference to a `{KEY}`. <br/>*Parameters*<br/>:small_red_triangle: **urls**: One or more URLs identifying where the notification should be sent to. If this field isn't specified then it automatically assumes the `settings.APPRISE_STATELESS_URLS` value or `APPRISE_STATELESS_URLS` environment variable.<br/>:small_red_triangle: **body**: Your message body. This is a required field.<br/>:small_red_triangle: **title**: Optionally define a title to go along with the *body*.<br/>:small_red_triangle: **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `error`. If no *type* is specified then `info` is the default value used.
+| Path         | Method | Description |
+|------------- | ------ | ----------- |
+| `/add/{KEY}` |  POST  | Saves Apprise Configuration (or set of URLs) to the persistent store.<br/>*Parameters*<br/>:small_red_triangle: **urls**: Used to define one or more Apprise URL(s). Use a comma and/or space to separate one URL from the next.<br/>:small_red_triangle: **config**: Provide the contents of either a YAML or TEXT based Apprise configuration.<br/>:small_red_triangle: **format**: This field is only required if you've specified the _config_ parameter. Used to tell the server which of the supported (Apprise) configuration types you are passing. Valid options are _text_ and _yaml_.
+| `/del/{KEY}` |  POST  | Removes Apprise Configuration from the persistent store.
+| `/get/{KEY}` |  POST  |  Returns the Apprise Configuration from the persistent store.  This can be directly used with the *Apprise CLI* and/or the *AppriseConfig()* object ([see here for details](https://github.com/caronc/apprise/wiki/config)).
+| `/notify/{KEY}` |  POST  |  Sends a notification based on the Apprise Configuration associated with the specified *{KEY}*.<br/>*Parameters*<br/>:small_red_triangle: **body**: Your message body. This is the *only* required field.<br/>:small_red_triangle: **title**: Optionally define a title to go along with the *body*.<br/>:small_red_triangle: **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `error`. If no *type* is specified then `info` is the default value used.<br/>:small_red_triangle: **tag**: Optionally notify only those tagged accordingly.
+| `/notify/` |  POST  | Similar to the `notify` API identified above except this one sends a stateless notification and requires no reference to a `{KEY}`. <br/>*Parameters*<br/>:small_red_triangle: **urls**: One or more URLs identifying where the notification should be sent to. If this field isn't specified then it automatically assumes the `settings.APPRISE_STATELESS_URLS` value or `APPRISE_STATELESS_URLS` environment variable.<br/>:small_red_triangle: **body**: Your message body. This is a required field.<br/>:small_red_triangle: **title**: Optionally define a title to go along with the *body*.<br/>:small_red_triangle: **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `error`. If no *type* is specified then `info` is the default value used.
+| `/json/urls/{KEY}` |  GET  | Returns a JSON response object that contains all of the URLS and Tags associated with the key specified.
+
+The `/json/urls/{KEY}` response might look like this:
+```json
+{
+   "tags": ["devops", "admin", "me"],
+   "urls": [
+      {
+         "url": "slack://TokenA/TokenB/TokenC",
+         "tags": ["devops", "admin"]
+      },
+      {
+         "url": "discord://WebhookID/WebhookToken",
+         "tags": ["devops"]
+      },
+      {
+         "url": "mailto://user:pass@gmail.com",
+         "tags": ["me"]
+      }
+   ]
+}
+```
 
 ### API Notes
 
 - `{KEY}` must be 1-64 alphanumeric characters in length. In addition to this, the underscore (`_`) and dash (`-`) are also accepted.
-- You must `POST` to URLs defined above in order for them to respond.
 - Specify the `Content-Type` of `application/json` to use the JSON support.
 - There is no authentication (or SSL encryption) required to use this API; this is by design. The intentio here to be a lightweight and fast micro-service that can be parked behind another tier that was designed to handle security.
 - There are no additional dependencies should you choose to use the optional persistent store (mounted as `/config`).
@@ -69,8 +90,8 @@ The use of environment variables allow you to provide over-rides to default sett
 
 | Variable             | Description |
 |--------------------- | ----------- |
-| `APPRISE_CONFIG_DIR` | Defines the persistent store location of all configuration files saved. By default:<br/> - Configuration is written to the `apprise_api/var/config` directory when just using the _Django_ `manage runserver` script.
-| `APPRISE_STATELESS_URLS` | A default set of URLs to notify when using the stateless `/notify` reference (no reference to `{KEY}` variables). Use this option if you don't intend to use the persistent store at all.
+| `APPRISE_CONFIG_DIR` | Defines an (optional) persistent store location of all configuration files saved. By default:<br/> - Configuration is written to the `apprise_api/var/config` directory when just using the _Django_ `manage runserver` script. However for the path for containers is `/config`
+| `APPRISE_STATELESS_URLS` | For a non-persistent solution, you can take avantage of this global variable. Use this to define a default set of Apprise URLs to notify when using API calls to `/notify`.  If no `{KEY}` is defined when calling `/notify` then the URLs defined here are used instead.
 | `SECRET_KEY`       | A Django variable acting as a *salt* for most things that require security. This API uses it for the hash sequences when writing the configuration files to disk.
 | `ALLOWED_HOSTS`    | A list of strings representing the host/domain names that this API can serve. This is a security measure to prevent HTTP Host header attacks, which are possible even under many seemingly-safe web server configurations. By default this is set to `*` allowing any host. Use space to delimit more then one host.
 | `DEBUG`            | This defaults to `False` however can be set to `True`if defined with a non-zero value (such as `1`).

--- a/apprise_api/api/tests/test_get.py
+++ b/apprise_api/api/tests/test_get.py
@@ -77,11 +77,6 @@ class GetTests(SimpleTestCase):
                    - dbus://"""})
         assert response.status_code == 200
 
-        # Verify that the correct Content-Type is set in the header of the
-        # response
-        assert 'Content-Type' in response
-        assert response['Content-Type'].startswith('text/plain')
-
         # Now retrieve our YAML configuration
         response = self.client.post('/get/{}'.format(key))
         assert response.status_code == 200

--- a/apprise_api/api/tests/test_json_urls.py
+++ b/apprise_api/api/tests/test_json_urls.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+from django.test import SimpleTestCase
+from unittest.mock import patch
+
+
+class JsonUrlsTests(SimpleTestCase):
+
+    def test_get_invalid_key_status_code(self):
+        """
+        Test GET requests to invalid key
+        """
+        response = self.client.get('/get/**invalid-key**')
+        assert response.status_code == 404
+
+    def test_post_not_supported(self):
+        """
+        Test POST requests with key
+        """
+        response = self.client.post('/json/urls/test')
+        # 405 as posting is not allowed
+        assert response.status_code == 405
+
+    def test_json_urls_config(self):
+        """
+        Test retrieving configuration
+        """
+
+        # our key to use
+        key = 'test_json_urls_config'
+
+        # Nothing to return
+        response = self.client.get('/json/urls/{}'.format(key))
+        assert response.status_code == 204
+
+        # Add some content
+        response = self.client.post(
+            '/add/{}'.format(key),
+            {'urls': 'mailto://user:pass@yahoo.ca'})
+        assert response.status_code == 200
+
+        # Handle case when we try to retrieve our content but we have no idea
+        # what the format is in. Essentialy there had to have been disk
+        # corruption here or someone meddling with the backend.
+        with patch('gzip.open', side_effect=OSError):
+            response = self.client.get('/json/urls/{}'.format(key))
+            assert response.status_code == 500
+            assert response['Content-Type'].startswith('application/json')
+            assert 'tags' in response.json()
+            assert 'urls' in response.json()
+
+            # has error directive
+            assert 'error' in response.json()
+
+            # entries exist by are empty
+            assert len(response.json()['tags']) == 0
+            assert len(response.json()['urls']) == 0
+
+        # Now we should be able to see our content
+        response = self.client.get('/json/urls/{}'.format(key))
+        assert response.status_code == 200
+        assert response['Content-Type'].startswith('application/json')
+        assert 'tags' in response.json()
+        assert 'urls' in response.json()
+
+        # No errors occured, therefore no error entry
+        assert 'error' not in response.json()
+
+        # No tags (but can be assumed "all") is always present
+        assert len(response.json()['tags']) == 0
+
+        # One URL loaded
+        assert len(response.json()['urls']) == 1
+        assert 'url' in response.json()['urls'][0]
+        assert 'tags' in response.json()['urls'][0]
+        assert len(response.json()['urls'][0]['tags']) == 0
+
+        # Add a YAML file
+        response = self.client.post(
+            '/add/{}'.format(key), {
+                'format': 'yaml',
+                'config': """
+                urls:
+                   - dbus://:
+                       - tag: tag1, tag2"""})
+        assert response.status_code == 200
+
+        # Now retrieve our JSON resonse
+        response = self.client.get('/json/urls/{}'.format(key))
+        assert response.status_code == 200
+
+        # No errors occured, therefore no error entry
+        assert 'error' not in response.json()
+
+        # No tags (but can be assumed "all") is always present
+        assert len(response.json()['tags']) == 2
+
+        # One URL loaded
+        assert len(response.json()['urls']) == 1
+        assert 'url' in response.json()['urls'][0]
+        assert 'tags' in response.json()['urls'][0]
+        assert len(response.json()['urls'][0]['tags']) == 2
+
+        # Handle case when we try to retrieve our content but we have no idea
+        # what the format is in. Essentialy there had to have been disk
+        # corruption here or someone meddling with the backend.
+        with patch('tempfile._TemporaryFileWrapper') as mock_ntf:
+            mock_ntf.side_effect = OSError()
+            # Now retrieve our JSON resonse
+            response = self.client.get('/json/urls/{}'.format(key))
+            assert response.status_code == 500
+            assert response['Content-Type'].startswith('application/json')
+            assert 'tags' in response.json()
+            assert 'urls' in response.json()
+
+            # has error directive
+            assert 'error' in response.json()
+
+            # entries exist by are empty
+            assert len(response.json()['tags']) == 0
+            assert len(response.json()['urls']) == 0
+
+        # Verify that the correct Content-Type is set in the header of the
+        # response
+        assert 'Content-Type' in response
+        assert response['Content-Type'].startswith('application/json')

--- a/apprise_api/api/urls.py
+++ b/apprise_api/api/urls.py
@@ -47,4 +47,7 @@ urlpatterns = [
     re_path(
         r'^notify/?',
         views.StatelessNotifyView.as_view(), name='s_notify'),
+    re_path(
+        r'^json/urls/(?P<key>[\w_-]{1,64})/?',
+        views.JsonUrlView.as_view(), name='json_urls'),
 ]


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #1 

The idea of this pull request is to add an additional API call to `/json/urls/{key}` which returns a JSON object identifying all of the URLs (and tags) loaded on the key identified.

- a 500 is returned on error
- a 204 (no data found) is returned if nothing is loaded for given key
- you must perform a **GET** to retrieve this information.
- a 200 response is returned when content is successfully returned.

The response might look like:
```json
{
   "tags": ["devops", "admin", "me"],
   "urls": [
      {
         "url": "slack://TokenA/TokenB/TokenC",
         "tags": ["devops", "admin"]
      },
      {
         "url": "discord://WebhookID/WebhookToken",
         "tags": ["devops"]
      },
      {
         "url": "mailto://user:pass@gmail.com",
         "tags": ["me"]
      }
   ]
}
```

In the event there is an error (a non-200 code response), an additional `error` directive will be set. In this case the response might look like:
```json
{
   "tags": [],
   "urls": [],
   "error": "The configuration could not be loaded."
}
```

In all cases, a JSON object is always returned.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
