### PR TITLE
Testing reworked to handle NamedTemporaryFile() issue

### DIFF
--- a/apprise_api/api/tests/test_add.py
+++ b/apprise_api/api/tests/test_add.py
@@ -162,8 +162,8 @@ class AddTests(SimpleTestCase):
         )
         assert response.status_code == 400
 
-        with patch('tempfile._TemporaryFileWrapper') as mock_ntf:
-            mock_ntf.side_effect = OSError()
+        with patch('tempfile.NamedTemporaryFile') as mock_ntf:
+            mock_ntf.side_effect = OSError
             # we won't be able to write our retrieved configuration
             # to disk for processing; we'll get a 500 error
             response = self.client.post(

--- a/apprise_api/api/tests/test_json_urls.py
+++ b/apprise_api/api/tests/test_json_urls.py
@@ -126,8 +126,8 @@ class JsonUrlsTests(SimpleTestCase):
         # Handle case when we try to retrieve our content but we have no idea
         # what the format is in. Essentialy there had to have been disk
         # corruption here or someone meddling with the backend.
-        with patch('tempfile._TemporaryFileWrapper') as mock_ntf:
-            mock_ntf.side_effect = OSError()
+        with patch('tempfile.NamedTemporaryFile') as mock_ntf:
+            mock_ntf.side_effect = OSError
             # Now retrieve our JSON resonse
             response = self.client.get('/json/urls/{}'.format(key))
             assert response.status_code == 500

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -168,8 +168,8 @@ class NotifyTests(SimpleTestCase):
             'body': 'test message'
         }
 
-        with patch('tempfile._TemporaryFileWrapper') as mock_ntf:
-            mock_ntf.side_effect = OSError()
+        with patch('tempfile.NamedTemporaryFile') as mock_ntf:
+            mock_ntf.side_effect = OSError
             # we won't be able to write our retrieved configuration
             # to disk for processing; we'll get a 500 error
             response = self.client.post(

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -39,7 +39,7 @@ from .forms import AddByConfigForm
 from .forms import NotifyForm
 from .forms import NotifyByUrlForm
 
-from tempfile import NamedTemporaryFile
+import tempfile
 import apprise
 import json
 import re
@@ -186,7 +186,7 @@ class AddView(View):
 
             try:
                 # Write our file to a temporary file
-                with NamedTemporaryFile() as f:
+                with tempfile.NamedTemporaryFile() as f:
                     # Write our content to disk
                     f.write(content['config'].encode())
                     f.flush()
@@ -395,7 +395,7 @@ class NotifyView(View):
             # so that we can read it back.  In the future a change will be to
             # Apprise so that we can just directly write the configuration as
             # is to the AppriseConfig() object... but for now...
-            with NamedTemporaryFile() as f:
+            with tempfile.NamedTemporaryFile() as f:
                 # Write our content to disk
                 f.write(config.encode())
                 f.flush()
@@ -569,7 +569,7 @@ class JsonUrlView(View):
             # so that we can read it back.  In the future a change will be to
             # Apprise so that we can just directly write the configuration as
             # is to the AppriseConfig() object... but for now...
-            with NamedTemporaryFile() as f:
+            with tempfile.NamedTemporaryFile() as f:
                 # Write our content to disk
                 f.write(config.encode())
                 f.flush()


### PR DESCRIPTION
## Description:
Thanks to the amazing efforts of @nedbat and [nedbat/coveragepy/issue/915](https://github.com/nedbat/coveragepy/issues/915); this wraps up `mock` references to `NamedTemporaryFile()`

### Reference
- [Travis CI Ref](https://travis-ci.community/t/python-3-6-sqlite3-operationalerror-disk-i-o-error/6737)
- [Ned Batchelder's Blog - Call for Help - Bug 915](https://nedbatchelder.com/blog/202001/bug_915_please_help.html)
- [Hacker News Ref](https://news.ycombinator.com/item?id=22030974)
- [Ned Batchelder's Blog - Bug 915 Solved](https://nedbatchelder.com/blog/202001/bug_915_solved.html)
## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
