### PR TITLE
api reference to tags should have read tag

### DIFF
--- a/apprise_api/api/templates/welcome.html
+++ b/apprise_api/api/templates/welcome.html
@@ -401,7 +401,7 @@
                     </td>
                   </tr>
                   <tr>
-                    <td>tags</td>
+                    <td>tag</td>
                     <td>{% blocktrans %}Apply tagging logic to the further filter your URLs. This is an optional
                       field.{% endblocktrans %}</td>
                   </tr>
@@ -413,7 +413,7 @@
                   <div class="collapsible-body">
                     <pre><code class="bash">
 								    # {% blocktrans %}Notifies all URLs assigned the <em>devops</em> tag{% endblocktrans %}<br/>
-								    curl -X POST -d '{"tags":"devops","body":"test body","title":"test title"}' \<br/>
+								    curl -X POST -d '{"tag":"devops","body":"test body","title":"test title"}' \<br/>
 										&nbsp;&nbsp;&nbsp;&nbsp;-H "Content-Type: application/json" \<br/>
 										&nbsp;&nbsp;&nbsp;&nbsp;http://localhost:8000/notify/<em>KEY</em></code></pre>
                   </div>
@@ -426,7 +426,7 @@
                         from urllib.request import Request<br/>
                         <br/>
                         payload = {<br/>
-                        &nbsp;&nbsp;&nbsp;&nbsp;'tags': 'devops',<br/>
+                        &nbsp;&nbsp;&nbsp;&nbsp;'tag': 'devops',<br/>
                         &nbsp;&nbsp;&nbsp;&nbsp;'title': 'test title',<br/>
                         &nbsp;&nbsp;&nbsp;&nbsp;'body': 'test body',<br/>
                         }<br/>
@@ -453,7 +453,7 @@
                        <br/>
                       //The JSON data.<br/>
                       $jsonData = array(<br/>
-                      &nbsp;&nbsp;&nbsp;&nbsp;'tags' => 'devops',<br/>
+                      &nbsp;&nbsp;&nbsp;&nbsp;'tag' => 'devops',<br/>
                       &nbsp;&nbsp;&nbsp;&nbsp;'title' => 'test title',<br/>
                       &nbsp;&nbsp;&nbsp;&nbsp;'body' => 'test body'<br/>
                       );<br/>


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #14 
Addresses issue on welcome page which provides examples that do not work with reference to `tag`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
