### PR TITLE
Drop unnecessary file I/O handling + Auto-Detect Configuration Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ As an example, the `/json/urls/{KEY}` response might return something like this:
 Here is an example using `curl` as to how someone might send a notification to everyone associated with the tag `abc123` (using `/notify/{key}`):
 ```bash
 # Send notification(s) to a {key} defined as 'abc123'
+curl -X POST -d "body=test message" \
+    http://localhost:8000/notify/abc123
+
+# Here is the same request but using JSON instead:
 curl -X POST -d '{"body":"test message"}' \
     -H "Content-Type: application/json" \
     http://localhost:8000/notify/abc123
@@ -118,6 +122,10 @@ curl -X POST -d '{"body":"test message"}' \
 ```bash
 # Send notification(s) to a {key} defined as 'abc123'
 # but only notify the URLs associated with the 'devops' tag
+curl -X POST -d 'tag=devops&body=test message' \
+    http://localhost:8000/notify/abc123
+
+# Here is the same request but using JSON instead:
 curl -X POST -d '{"tag":"devops", "body":"test message"}' \
     -H "Content-Type: application/json" \
     http://localhost:8000/notify/abc123

--- a/apprise_api/api/forms.py
+++ b/apprise_api/api/forms.py
@@ -27,8 +27,12 @@ import apprise
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+# Auto-Detect Keyword
+AUTO_DETECT_CONFIG_KEYWORD = 'auto'
+
 # Define our potential configuration types
 CONFIG_FORMATS = (
+    (AUTO_DETECT_CONFIG_KEYWORD, _('Auto-Detect')),
     (apprise.ConfigFormat.TEXT, _('TEXT')),
     (apprise.ConfigFormat.YAML, _('YAML')),
 )

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -117,9 +117,11 @@ async function update() {
   // perform our status check
   let response = await fetch('{% url "get" key %}', {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json;charset=utf-8'
+    },
   });
 
-  let result = await response;
   if(response.status == 204)
   {
     // no problem; we simply have no content to retrieve
@@ -133,10 +135,22 @@ async function update() {
     document.querySelector('.config-overview li a[href="#notify"]')
       .parentNode.classList.remove('disabled');
 
+    // get our results
+    let result = await response.json();
+
     // Set our configuration so it's visible
-    response.text().then(function (text) {
-      document.querySelector('#id_config').value = text;
-    });
+    document.querySelector('#id_config').value = result.config;
+    // Set our format
+    document.querySelector('#id_format').value = result.format;
+
+    // dispatch our event to update our select box
+    if (typeof(Event) === 'function') {
+        var event = new Event('change');
+    } else {  // for IE11
+        var event = document.createEvent('Event');
+        event.initEvent('change', true, true);
+    }
+    document.querySelector('#id_format').dispatchEvent(event);
 
     // Ensure has-config sections are visible
     document.querySelector('.has-config')

--- a/apprise_api/api/tests/test_add.py
+++ b/apprise_api/api/tests/test_add.py
@@ -162,20 +162,6 @@ class AddTests(SimpleTestCase):
         )
         assert response.status_code == 400
 
-        with patch('tempfile.NamedTemporaryFile') as mock_ntf:
-            mock_ntf.side_effect = OSError
-            # we won't be able to write our retrieved configuration
-            # to disk for processing; we'll get a 500 error
-            response = self.client.post(
-                '/add/{}'.format(key),
-                data=json.dumps(
-                    {'format': ConfigFormat.TEXT, 'config': config}),
-                content_type='application/json',
-            )
-
-            # internal errors are correctly identified
-            assert response.status_code == 500
-
         # Test the handling of underlining disk/write exceptions
         with patch('gzip.open') as mock_open:
             mock_open.side_effect = OSError()

--- a/apprise_api/api/tests/test_add.py
+++ b/apprise_api/api/tests/test_add.py
@@ -139,7 +139,7 @@ class AddTests(SimpleTestCase):
 
         # Valid Text Configuration
         config = """
-        browser,media=notica://VToken
+        browser,media=notica://VTokenC
         home=mailto://user:pass@hotmail.com
         """
         response = self.client.post(
@@ -158,9 +158,9 @@ class AddTests(SimpleTestCase):
         # Valid Yaml Configuration
         config = """
         urls:
-          - notica://VToken:
+          - notica://VTokenD:
               tag: browser,media
-          - mailto://user:pass@hotmail.com
+          - mailto://user:pass@hotmail.com:
               tag: home
         """
         response = self.client.post(
@@ -191,7 +191,7 @@ class AddTests(SimpleTestCase):
             response = self.client.post(
                 '/add/{}'.format(key),
                 data=json.dumps(
-                    {'format': ConfigFormat.TEXT, 'config': config}),
+                    {'format': ConfigFormat.YAML, 'config': config}),
                 content_type='application/json',
             )
 
@@ -217,7 +217,7 @@ class AddTests(SimpleTestCase):
 
         # Valid Text Configuration
         config = """
-        browser,media=notica://VToken
+        browser,media=notica://VTokenA
         home=mailto://user:pass@hotmail.com
         """
         response = self.client.post(
@@ -236,8 +236,11 @@ class AddTests(SimpleTestCase):
         # Valid Yaml Configuration
         config = """
         urls:
-          - browser,media=notica://VToken
-          - home=mailto://user:pass@hotmail.com
+          - notica://VTokenB:
+              tag: browser,media
+
+          - mailto://user:pass@hotmail.com:
+              tag: home
         """
         response = self.client.post(
             '/add/{}'.format(key),

--- a/apprise_api/api/tests/test_json_urls.py
+++ b/apprise_api/api/tests/test_json_urls.py
@@ -136,25 +136,6 @@ class JsonUrlsTests(SimpleTestCase):
         assert 'tags' in response.json()['urls'][0]
         assert len(response.json()['urls'][0]['tags']) == 2
 
-        # Handle case when we try to retrieve our content but we have no idea
-        # what the format is in. Essentialy there had to have been disk
-        # corruption here or someone meddling with the backend.
-        with patch('tempfile.NamedTemporaryFile') as mock_ntf:
-            mock_ntf.side_effect = OSError
-            # Now retrieve our JSON resonse
-            response = self.client.get('/json/urls/{}'.format(key))
-            assert response.status_code == 500
-            assert response['Content-Type'].startswith('application/json')
-            assert 'tags' in response.json()
-            assert 'urls' in response.json()
-
-            # has error directive
-            assert 'error' in response.json()
-
-            # entries exist by are empty
-            assert len(response.json()['tags']) == 0
-            assert len(response.json()['urls']) == 0
-
         # Verify that the correct Content-Type is set in the header of the
         # response
         assert 'Content-Type' in response

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -212,20 +212,6 @@ class NotifyTests(SimpleTestCase):
             'body': 'test message'
         }
 
-        with patch('tempfile.NamedTemporaryFile') as mock_ntf:
-            mock_ntf.side_effect = OSError
-            # we won't be able to write our retrieved configuration
-            # to disk for processing; we'll get a 500 error
-            response = self.client.post(
-                '/notify/{}'.format(key),
-                data=json.dumps(json_data),
-                content_type='application/json',
-            )
-
-            # internal errors are correctly identified
-            assert response.status_code == 500
-            assert mock_notify.call_count == 0
-
         # Test the handling of underlining disk/write exceptions
         with patch('gzip.open') as mock_open:
             mock_open.side_effect = OSError()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django
-apprise
+apprise >= 0.8.8


### PR DESCRIPTION
## Description:
The following changes come bundled in this Pull Request (PR):
* Code clean up can be done with `AppriseConfig.add_config()` function and the new `ConfigMemory()` type  (_introduced in [PR apprise/199](https://github.com/caronc/apprise/pull/199)_) which eliminates the need to write the configuration to a file just so that it can be re-read.
* Configuration format can be auto-detected now (when deciding if it is `YAML` or `TEXT`)

**Note**: Test cases won't pass until [PR apprise/282](https://github.com/caronc/apprise/pull/282) makes it upstream into the official version.  The `requirements.txt` has already been updated to point to it.  For this reason this PR will remain open until Apprise catches up. Code has been tested to work great against the Apprise/Master branch though.

## Checklist
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
