### PR TITLE
Default body format handling added

### DIFF
--- a/apprise_api/api/forms.py
+++ b/apprise_api/api/forms.py
@@ -44,6 +44,15 @@ NOTIFICATION_TYPES = (
     (apprise.NotifyType.FAILURE, _('Failure')),
 )
 
+# Define our potential input text categories
+INPUT_FORMATS = (
+    (apprise.NotifyFormat.TEXT, _('TEXT')),
+    (apprise.NotifyFormat.MARKDOWN, _('MARKDOWN')),
+    (apprise.NotifyFormat.HTML, _('HTML')),
+    # As-is - do not interpret it
+    (None, _('IGNORE')),
+)
+
 URLS_MAX_LEN = 1024
 URLS_PLACEHOLDER = 'mailto://user:pass@domain.com, ' \
                    'slack://tokena/tokenb/tokenc, ...'
@@ -88,6 +97,13 @@ class NotifyForm(forms.Form):
     potential asset information (if yaml file) and tag details.
     """
 
+    format = forms.ChoiceField(
+        label=_('Process As'),
+        initial=INPUT_FORMATS[0][0],
+        choices=INPUT_FORMATS,
+        required=False,
+    )
+
     type = forms.ChoiceField(
         label=_('Type'),
         choices=NOTIFICATION_TYPES,
@@ -123,6 +139,16 @@ class NotifyForm(forms.Form):
         if not data:
             # Always set a type
             data = apprise.NotifyType.INFO
+        return data
+
+    def clean_format(self):
+        """
+        We just ensure there is a format always set
+        """
+        data = self.cleaned_data['format']
+        if not data:
+            # Always set a type
+            data = apprise.NotifyFormat.TEXT
         return data
 
 

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -376,6 +376,13 @@ class NotifyView(View):
                 _('An invalid payload was specified.'),
                 status=ResponseCode.bad_request)
 
+        # Acquire our body format (if identified)
+        body_format = content.get('format', apprise.NotifyFormat.TEXT)
+        if body_format and body_format not in apprise.NOTIFY_FORMATS:
+            return HttpResponse(
+                _('An invalid body input format was specified.'),
+                status=ResponseCode.bad_request)
+
         # If we get here, we have enough information to generate a notification
         # with.
         config, format = ConfigCache.get(key)
@@ -400,9 +407,8 @@ class NotifyView(View):
             )
 
         # Prepare ourselves a default Asset
-        asset = apprise.AppriseAsset(
-            body_format=apprise.NotifyFormat.TEXT,
-        )
+        asset = None if not body_format else \
+            apprise.AppriseAsset(body_format=body_format)
 
         # Prepare our apprise object
         a_obj = apprise.Apprise(asset=asset)
@@ -487,10 +493,16 @@ class StatelessNotifyView(View):
                 _('An invalid payload was specified.'),
                 status=ResponseCode.bad_request)
 
+        # Acquire our body format (if identified)
+        body_format = content.get('format', apprise.NotifyFormat.TEXT)
+        if body_format and body_format not in apprise.NOTIFY_FORMATS:
+            return HttpResponse(
+                _('An invalid (body) format was specified.'),
+                status=ResponseCode.bad_request)
+
         # Prepare ourselves a default Asset
-        asset = apprise.AppriseAsset(
-            body_format=apprise.NotifyFormat.TEXT,
-        )
+        asset = None if not body_format else \
+            apprise.AppriseAsset(body_format=body_format)
 
         # Prepare our apprise object
         a_obj = apprise.Apprise(asset=asset)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes n/a

This merge request just allows the default body format to be both configurable and preset to `TEXT` for a more consistent and expected notification flow.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
