### PR TITLE
Added console logging with optional LOG_LEVEL env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The use of environment variables allow you to provide over-rides to default sett
 | `SECRET_KEY`       | A Django variable acting as a *salt* for most things that require security. This API uses it for the hash sequences when writing the configuration files to disk (`hash` mode only).
 | `ALLOWED_HOSTS`    | A list of strings representing the host/domain names that this API can serve. This is a security measure to prevent HTTP Host header attacks, which are possible even under many seemingly-safe web server configurations. By default this is set to `*` allowing any host. Use space to delimit more than one host.
 | `BASE_URL`    | Those who are hosting the API behind a proxy that requires a subpath to gain access to this API should specify this path here as well.  By default this is not set at all.
+| `LOG_LEVEL`    | Adjust the log level to the console; the default value is `DEBUG` if the `DEBUG` is set below otherwise the default is `INFO`. Possible values are `ERROR`, `WARNING`, `INFO`, and `DEBUG`.
 | `DEBUG`            | This defaults to `False` however can be set to `True` if defined with a non-zero value (such as `1`).
 
 

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -77,6 +77,29 @@ TEMPLATES = [
     },
 ]
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard'
+        },
+    },
+    'loggers': {
+        'apprise': {
+            'handlers': ['console'],
+            'level': os.environ.get(
+                'LOG_LEVEL', 'debug' if DEBUG else 'info').upper(),
+        },
+    }
+}
+
 WSGI_APPLICATION = 'core.wsgi.application'
 
 # Define our base URL


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes n/a

Added console logging so you can actually see what is going on with each call to the underlining `apprise` service.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
