### PR TITLE
Improved persistent configuration permission docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,38 @@ A `docker-compose.yml` file is already set up to grant you an instant production
 docker-compose up
 ```
 
+### Config Directory Permissions
+Under the hood, An NginX services is reading/writing your configuration files as the user (and group) `www-data` which generally has the id of `33`.  In preparation so that you don't get the error: `An error occured saving configuration.` consider also setting up your local `/var/lib/apprise/config` permissions as:
+
+```bash
+# Create a user/group (if one doesn't already exist) owned
+# by the user and group id of 33
+id 33 &>/dev/null || sudo useradd \
+   --system --no-create-home --shell /bin/false \
+    -u 33 -g 33 www-data
+
+# Securely set the directory limiting access to only those who
+# are part of the www-data group:
+sudo chmod 770 -R /var/lib/apprise/config
+sudo chown 33:33 -R /var/lib/apprise/config
+
+# Now optionally add yourself to the group if you wish to be able to view
+# contents.
+sudo usermod -a -G 33 $(whoami)
+
+# You may need to log out and back in again for the above usermod
+# to reflect on you.  Alternatively you can just type the following
+# and it will work as a temporary solution:
+sudo su - $(whoami)
+```
+
+Alternatively a dirty solution is to just set the directory with full read/write permissions (which is not ideal in a production environment):
+```bash
+# Grant full permission to the local directory you're saving your
+# Apprise configuration to:
+chmod 777 /var/lib/apprise/config
+```
+
 ## Dockerfile Details
 
 The following architectures are supported: `386`, `amd64`, `arm/v6`, `arm/v7`, and `arm64`. The following tags can be used:

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -267,11 +267,11 @@ document.querySelector('#addconfig').onsubmit = function(event) {
           '{% trans "Successfully saved the specified URL(s)." %}',
           'success'
         );
-     } else if(response.status > 500) {
+     } else if(response.status == 500) {
         // Disk issue
         Swal.fire(
           '{% trans "Save" %}',
-          '{% trans "There was an issue writing the configuration to your filesystem. Check your file permissions and try again." %}',
+          '{% trans "There was an issue writing the configuration to disk. Check your file permissions and try again." %}',
           'error'
         );
      } else {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #43 and #31 

Doc changes to the **README.md** are as follows:

> ### Config Directory Permissions
> Under the hood, An NginX services is reading/writing your configuration files as the user (and group) `www-data` which generally has the id of `33`.  In preparation so that you don't get the error: `An error occured saving configuration.` consider also setting up your local `/var/lib/apprise/config` permissions as:
> 
> ```bash
> # Create a user/group (if one doesn't already exist) owned
> # by the user and group id of 33
> id 33 &>/dev/null || sudo useradd \
>    --system --no-create-home --shell /bin/false \
>     -u 33 -g 33 www-data
> 
> # Securely set the directory limiting access to only those who
> # are part of the www-data group:
> sudo chmod 770 -R /var/lib/apprise/config
> sudo chown 33:33 -R /var/lib/apprise/config
> 
> # Now optionally add yourself to the group if you wish to be able to view
> # contents.
> sudo usermod -a -G 33 $(whoami)
> 
> # You may need to log out and back in again for the above usermod
> # to reflect on you.  Alternatively you can just type the following
> # and it will work as a temporary solution:
> sudo su - $(whoami)
> ```

> Alternatively a dirty solution is to just set the directory with full read/write permissions (which is not ideal in a production environment):
> ```bash
> # Grant full permission to the local directory you're saving your
> # Apprise configuration to:
> chmod 777 /var/lib/apprise/config
> ```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] tests added
