### PR TITLE
healthcheck endpoint

### DIFF
--- a/apprise_api/api/tests/test_health.py
+++ b/apprise_api/api/tests/test_health.py
@@ -22,35 +22,15 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from django.urls import re_path
-from . import views
+from django.test import SimpleTestCase
 
-urlpatterns = [
-    re_path(
-        r'^$',
-        views.WelcomeView.as_view(), name='welcome'),
-    re_path(
-        r'^cfg/(?P<key>[\w_-]{1,64})/?',
-        views.ConfigView.as_view(), name='config'),
-    re_path(
-        r'^add/(?P<key>[\w_-]{1,64})/?',
-        views.AddView.as_view(), name='add'),
-    re_path(
-        r'^del/(?P<key>[\w_-]{1,64})/?',
-        views.DelView.as_view(), name='del'),
-    re_path(
-        r'^get/(?P<key>[\w_-]{1,64})/?',
-        views.GetView.as_view(), name='get'),
-    re_path(
-        r'^notify/(?P<key>[\w_-]{1,64})/?',
-        views.NotifyView.as_view(), name='notify'),
-    re_path(
-        r'^notify/?',
-        views.StatelessNotifyView.as_view(), name='s_notify'),
-    re_path(
-        r'^json/urls/(?P<key>[\w_-]{1,64})/?',
-        views.JsonUrlView.as_view(), name='json_urls'),
-    re_path(
-        r'^health/?',
-        views.HealthCheckView.as_view(), name='healthcheck'),
-]
+
+class HealthCheckTests(SimpleTestCase):
+
+    def test_health_check_status_code(self):
+        response = self.client.get('/health')
+        assert response.status_code == 200
+
+    def test_health_check_response_body(self):
+        response = self.client.get('/health')
+        assert response.content == b'OK'

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -694,3 +694,18 @@ class JsonUrlView(View):
             safe=False,
             status=ResponseCode.okay
         )
+
+
+class HealthCheckView(View):
+    """
+    A Django view that renders plain text "OK" for service discovery tools
+    """
+    def get(self, request):
+        """
+        Handle a GET request
+        """
+        return HttpResponse(
+            'OK',
+            content_type='text/plain',
+            status=ResponseCode.okay
+        )


### PR DESCRIPTION
## Description:
This PR adds a `/health` endpoint which does nothing more than returning plaintext `OK` response. It is useful for service discovery tools (consul/kubernetes etc.), to quickly say, that service is alive and running. Currently, to achieve that, I had to ping `/` which returned a lot of unnecessary data.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
