### PR TITLE
Server-side handling of new apprise:// schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The use of environment variables allow you to provide over-rides to default sett
 
 | `SECRET_KEY`       | A Django variable acting as a *salt* for most things that require security. This API uses it for the hash sequences when writing the configuration files to disk (`hash` mode only).
 | `ALLOWED_HOSTS`    | A list of strings representing the host/domain names that this API can serve. This is a security measure to prevent HTTP Host header attacks, which are possible even under many seemingly-safe web server configurations. By default this is set to `*` allowing any host. Use space to delimit more than one host.
+| `APPRISE_RECURSION_MAX` | This defines the number of times one Apprise API Server can (recursively) call another.  This is to both support and mitigate abuse through [the `apprise://` schema](https://github.com/caronc/apprise/wiki/Notify_apprise_api) for those who choose to use it. When leveraged properly, you can increase this (recursion max) value and successfully load balance the handling of many notification requests through many additional API Servers.  By default this value is set to `1` (one).
 | `BASE_URL`    | Those who are hosting the API behind a proxy that requires a subpath to gain access to this API should specify this path here as well.  By default this is not set at all.
 | `LOG_LEVEL`    | Adjust the log level to the console. Possible values are `CRITICAL`, `ERROR`, `WARNING`, `INFO`, and `DEBUG`.
 | `DEBUG`            | This defaults to `no` and can however be set to `yes` by simply defining the global variable as such.

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -113,6 +113,94 @@ class StatelessNotifyTests(SimpleTestCase):
         assert response.status_code == 424
         assert mock_notify.call_count == 2
 
+    @override_settings(APPRISE_RECURSION_MAX=1)
+    @patch('apprise.Apprise.notify')
+    def test_stateless_notify_recursion(self, mock_notify):
+        """
+        Test recursion an id header details as part of post
+        """
+
+        # Set our return value
+        mock_notify.return_value = True
+
+        headers = {
+            'HTTP_X-APPRISE-ID': 'abc123',
+            'HTTP_X-APPRISE-RECURSION-COUNT': str(1),
+        }
+
+        # Preare our form data (without url specified)
+        # content will fall back to default configuration
+        form_data = {
+            'urls': 'mailto://user:pass@hotmail.com',
+            'body': 'test notifiction',
+        }
+
+        # At a minimum 'body' is requred
+        form = NotifyByUrlForm(data=form_data)
+        assert form.is_valid()
+
+        # recursion value is within correct limits
+        response = self.client.post('/notify', form.cleaned_data, **headers)
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+
+        headers = {
+            # Header specified but with whitespace
+            'HTTP_X-APPRISE-ID': '  ',
+            # No Recursion value specified
+        }
+
+        # Reset our count
+        mock_notify.reset_mock()
+
+        # Recursion limit reached
+        response = self.client.post('/notify', form.cleaned_data, **headers)
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+
+        headers = {
+            'HTTP_X-APPRISE-ID': 'abc123',
+            # Recursion Limit hit
+            'HTTP_X-APPRISE-RECURSION-COUNT': str(2),
+        }
+
+        # Reset our count
+        mock_notify.reset_mock()
+
+        # Recursion limit reached
+        response = self.client.post('/notify', form.cleaned_data, **headers)
+        assert response.status_code == 406
+        assert mock_notify.call_count == 0
+
+        headers = {
+            'HTTP_X-APPRISE-ID': 'abc123',
+            # Negative recursion value (bad request)
+            'HTTP_X-APPRISE-RECURSION-COUNT': str(-1),
+        }
+
+        # Reset our count
+        mock_notify.reset_mock()
+
+        # invalid recursion specified
+        response = self.client.post('/notify', form.cleaned_data, **headers)
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        headers = {
+            'HTTP_X-APPRISE-ID': 'abc123',
+            # Invalid recursion value (bad request)
+            'HTTP_X-APPRISE-RECURSION-COUNT': 'invalid',
+        }
+
+        # Reset our count
+        mock_notify.reset_mock()
+
+        # invalid recursion specified
+        response = self.client.post('/notify', form.cleaned_data, **headers)
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+
     @override_settings(APPRISE_STATELESS_URLS="mailto://user:pass@localhost")
     @patch('apprise.Apprise.notify')
     def test_notify_default_urls(self, mock_notify):

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -200,7 +200,6 @@ class StatelessNotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
-
     @override_settings(APPRISE_STATELESS_URLS="mailto://user:pass@localhost")
     @patch('apprise.Apprise.notify')
     def test_notify_default_urls(self, mock_notify):

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -163,3 +163,9 @@ APPRISE_DENY_SERVICES = os.environ.get('APPRISE_DENY_SERVICES', ','.join((
 #  - anything not identified here is denied/disabled)
 #  - this list trumps the APPRISE_DENY_SERVICES identified above
 APPRISE_ALLOW_SERVICES = os.environ.get('APPRISE_ALLOW_SERVICES', '')
+
+# Define the number of recursive calls your system will allow users to make
+# The idea here is to prevent people from defining apprise:// URL's triggering
+# a call to the same server again, and again and again. By default we allow
+# 1 level of recursion
+APPRISE_RECURSION_MAX = int(os.environ.get('APPRISE_RECURSION_MAX', 1))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 django
-cryptography == 3.3.2
 apprise == 0.9.6
 
 # 3rd party service support


### PR DESCRIPTION
## Description:
In preparation for then new `apprise://` schema defined [here](https://github.com/caronc/apprise/wiki/Notify_apprise_api)  which allows users to use the Apprise CLI (or Python Development) to access and trigger additional notifications from an Apprise API server (this very service here). 

The preparation involves handling situations where someone has additionally defined the `apprise://` schema in this API Service. 

- :+1: **In a best case scenario**: one could load balance and have one API Server call another (and another) scaling the distribution of thousands of notifications.
 - :-1: **In a worst case scenario**: one could configure the Apprise API server to cal itself (endlessly doing so) to cause a Denial of Service (DoS).
     - **Note**: This is exactly what the `APPRISE_RECURSION_MAX` value is for (to prevent this). If you're operating the service behind a closed network however, it's safe to increase this default value of 1 to something higher.

This enhancement was built in parallel with the Apprise one and uses HTML headers that are passed in order to prevent and/or endorse this recursion feature. It introduces a new Global Environment Variable called `APPRISE_RECURSION_MAX` which defaults to a value of `1` (one).  This allows _this_ Apprise API service to recursively handle subsequent calls to `apprise://` defined notification services only once when being triggered from another Apprise API server and/or external call.

The [Apprise (upstream) ticket details can be found here](https://github.com/caronc/apprise/issues/451)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] tests added
