### PR TITLE
force version of cryptography that doesn't require Rust

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 django
+cryptography == 3.3
 apprise == 0.9.5.1
 
 # 3rd party service support


### PR DESCRIPTION
## Description:
Handle cryptography dependency issue since it now forces users to leverage Rust.

Since we aren't decrypting content (only encrypting for transmission), we aren't at risk for sticking to an earlier version for the time being.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)

