### PR TITLE
Underlining Apprise version info added to Frontend Display

### DIFF
--- a/apprise_api/api/context_processors.py
+++ b/apprise_api/api/context_processors.py
@@ -40,6 +40,7 @@ def config_lock(request):
     """
     return {'CONFIG_LOCK': settings.APPRISE_CONFIG_LOCK}
 
+
 def apprise_version(request):
     """
     Returns the current version of apprise loaded under the hood

--- a/apprise_api/api/context_processors.py
+++ b/apprise_api/api/context_processors.py
@@ -24,6 +24,7 @@
 # THE SOFTWARE.
 from .utils import ConfigCache
 from django.conf import settings
+import apprise
 
 
 def stateful_mode(request):
@@ -38,3 +39,9 @@ def config_lock(request):
     Returns the state of our global configuration lock
     """
     return {'CONFIG_LOCK': settings.APPRISE_CONFIG_LOCK}
+
+def apprise_version(request):
+    """
+    Returns the current version of apprise loaded under the hood
+    """
+    return {'APPRISE_VERSION': apprise.__version__}

--- a/apprise_api/api/templates/base.html
+++ b/apprise_api/api/templates/base.html
@@ -34,6 +34,7 @@
           <img class="left" src="{% static "logo.png" %}" alt="{% trans "Apprise Logo" %}" />
         </a>
         <h1>{% trans "Apprise API" %}</h1>
+        <i>APPRISE v{{APPRISE_VERSION}}</i>
       </div>
     </div>
     <!-- Page Layout here -->

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -26,17 +26,28 @@
         </li>
         <li>
           {% blocktrans %}
-          You can always refer to the
-          <a href="https://github.com/caronc/apprise/wiki#notification-services">Apprise Wiki</a> if you're having
-          troubles assembling your URL(s).
-          {% endblocktrans %}
-        </li>
-        <li>
-          {% blocktrans %}
           In the future you can return to this configuration screen at any time by placing the following into your
           browser:
           {% endblocktrans %}
           <code>{{request.scheme}}://{{request.META.HTTP_HOST}}{{BASE_URL}}/cfg/{{key}}</code>
+        </li>
+        <li>
+          {% blocktrans %}
+          Use the <strong><i class="material-icons">settings</i> Configuration</strong> section to prepare and save your Apprise configuration.
+          {% endblocktrans %}
+      <ul>
+        <li>
+          {% blocktrans %}
+          <i class="material-icons">lightbulb_outline</i>You can always refer to the
+          <a href="https://github.com/caronc/apprise/wiki#notification-services">Apprise Wiki</a> if you're having troubles assembling your URL(s).
+          {% endblocktrans %}
+        </li>
+      </ul>
+        </li>
+        <li>
+          {% blocktrans %}
+          Use the <strong><i class="material-icons">announcement</i> Notifications</strong> section to test out your saved configuration.
+          {% endblocktrans %}
         </li>
       </ol>
     </div>
@@ -62,7 +73,7 @@
     {% endif %}
     <div class="has-config">
       <div class="section">
-        <h5>{% trans "Working With Your Configuration" %}</h5>
+        <h5>{% trans "Working Remotely With Your Configuration" %}</h5>
         <p>
         {% blocktrans %}The following command would cause apprise to directly notify all of your services:{% endblocktrans %}
         <br />

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -76,6 +76,7 @@ TEMPLATES = [
                 'core.context_processors.base_url',
                 'api.context_processors.stateful_mode',
                 'api.context_processors.config_lock',
+                'api.context_processors.apprise_version',
             ],
         },
     },

--- a/apprise_api/static/css/base.css
+++ b/apprise_api/static/css/base.css
@@ -3,6 +3,14 @@
   font-size: 2.1rem;
   font-weight: bold;
   text-transform: uppercase;
+  float: left;
+}
+
+/* Apprise Version */
+.nav i {
+  float: right;
+	font-style: normal;
+  font-size: 0.7rem;
 }
 
 code {
@@ -40,6 +48,12 @@ textarea {
 
 .collapsible-body {
   padding: 1rem 2rem;
+}
+
+#overview strong {
+	color: #004d40;
+	display: inline-block;
+  background-color: #eee;
 }
 
 .tabs .tab a{


### PR DESCRIPTION
## Description:
- Underlining version of Apprise now shows
- Some added help information on main page

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
