### PR TITLE
slight re-wording on main configuration help screen

### DIFF
--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -53,11 +53,11 @@
     </div>
     <div class="section no-config">
       <div class="divider"></div>
-      <p><strong>
-          {% blocktrans %}To get started, the first thing you want to do is define your configuration. Do this by
-          clicking on the <i>Configuration tab</i>.
-          {% endblocktrans %}
-        </strong></p>
+      <p>
+      <i class="material-icons info">info</i>
+      {% blocktrans %}Once you have successfully load <i>at least one Apprise URL</i> on the <strong><i class="material-icons">settings</i> Configuration</strong> section, your loaded entries will display here.
+      {% endblocktrans %}
+      </p>
       <div class="divider"></div>
     </div>
     {% else %}

--- a/apprise_api/static/css/base.css
+++ b/apprise_api/static/css/base.css
@@ -42,6 +42,12 @@ em {
 	font-weight:bold;
 }
 
+.no-config .info {
+	color: #004d40;
+  font-size: 3.3rem;
+
+}
+
 textarea {
 	height: 16rem;
 }


### PR DESCRIPTION
## Description:
Just some slight reformatting and re-wording of the help information found on the main configuration page when there is no configuration set yet.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] tests added
