### PR TITLE
GET parms: title, type, format, and tag used if not in payload

### DIFF
--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -366,6 +366,9 @@ class StatelessNotifyTests(SimpleTestCase):
         # Ensure we're enabled for the purpose of our testing
         apprise.plugins.SCHEMA_MAP['json'].enabled = True
 
+        # Reset Mock
+        mock_send.reset_mock()
+
         # Send our service with the `json://` denied
         with override_settings(APPRISE_ALLOW_SERVICES=""):
             with override_settings(APPRISE_DENY_SERVICES="json"):

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -471,6 +471,7 @@ class NotifyView(View):
         content = {}
         if MIME_IS_FORM.match(request.content_type):
             content = {}
+
             form = NotifyForm(request.POST)
             if form.is_valid():
                 content.update(form.cleaned_data)
@@ -501,6 +502,34 @@ class NotifyView(View):
                 safe=False,
                 status=status,
             )
+
+        #
+        # Allow 'tag' value to be specified as part of the URL parameters
+        # if not found otherwise defined.
+        #
+        if not content.get('tag') and 'tag' in request.GET:
+            content['tag'] = request.GET['tag']
+
+        #
+        # Allow 'format' value to be specified as part of the URL
+        # parameters if not found otherwise defined.
+        #
+        if not content.get('format') and 'format' in request.GET:
+            content['format'] = request.GET['format']
+
+        #
+        # Allow 'type' value to be specified as part of the URL parameters
+        # if not found otherwise defined.
+        #
+        if not content.get('type') and 'type' in request.GET:
+            content['type'] = request.GET['type']
+
+        #
+        # Allow 'title' value to be specified as part of the URL parameters
+        # if not found otherwise defined.
+        #
+        if not content.get('title') and 'title' in request.GET:
+            content['title'] = request.GET['title']
 
         # Some basic error checking
         if not content.get('body') or \


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #83 

Now when posting to the Apprise API, if `tag=`, `title=`, `format=`, and `type=` are identified in in the URL (as parameters), they're value will be applied IF not otherwise present in the payload.

The `/notify` call still must be a POST call.  the additional support for the parameters just offer a additional defaults. 

For example:
# Send a 'test message' to all items tagged with 'personal'
```bash
# The below would target loaded configuration matching against the tag `personal`
curl -X POST -d '{"body":"test message"}' \
    -H "Content-Type: application/json" \
    "http://localhost:8000/notify/mykey?tag=personal"
```

Again, to reiterate, if the payload contains the keyword as well, it's value will always be used instead:
```bash
# The below would target loaded configuration matching against the tag `all`
# While the tag=spouse was passed on the GET Parameter (in the URL)
# it will not over-ride anything defined in the payload.
curl -X POST -d '{"body":"test message", "tag":"all"}' \
    -H "Content-Type: application/json" \
    "http://localhost:8000/notify/mykey?tag=spouse"
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] Tests added
