### PR TITLE
Fix failure to save settings on Windows

### DIFF
--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -131,6 +131,10 @@ class AppriseConfigCache(object):
 
         # Write our file to a temporary file
         _, tmp_path = tempfile.mkstemp(suffix='.tmp', dir=path)
+        # Close the file handle provided by mkstemp()
+        # We're reopening it, and it can't be renamed while open on Windows
+        os.close(_)
+
         if self.mode == AppriseStoreMode.HASH:
             try:
                 with gzip.open(tmp_path, 'wb') as f:


### PR DESCRIPTION
## Description:
Saving settings on Windows fails with:
```
Traceback (most recent call last):
  File "C:\Users\Nathan\.pyenv\pyenv-win\versions\3.11.3\Lib\shutil.py", line 825, in move
    os.rename(src, real_dst)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\Nathan\\.local\\apprise-api\\apprise_api\\var\\config\\27\\tmpi0utrc0z.tmp' -> 'C:\\Users\\Nathan\\.local\\apprise-api\\apprise_api\\var\\config\\27\\7a415748edb692e8bf8c4361e9777d92f2dfad2359bbd8c9fbcd49.text'
```

`mkstemp()` also returns an open file handle (that we don't use), which must be closed as Windows won't allow renaming an open file.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [X] Tests added
