### PR TITLE
Updated documentation and README to help with controlling Apprise Ver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV APPRISE_PLUGIN_PATHS /plugin
 
 # Install nginx, supervisord, and cryptography dependencies
 RUN apt-get update -qq && \
-    apt-get install -y -qq nginx supervisor \
+    apt-get install -y -qq nginx supervisor git \
     build-essential libffi-dev libssl-dev cargo pkg-config python3-dev rustc
 
 # Cryptography documents that the latest version of pip3 must always be used

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ docker run --name apprise \
    -d caronc/apprise:latest
 ```
 
+You can also choose to build yourself a custom version after checking out the source code. This is sometimes useful when you want to make a change to the source code and try it out.
+A common change one might make is to update the Dockerfile to point to the master branch of Apprise instead of using the stable version.
+```bash
+# Setup your environment the way you like
+docker build -t apprise/local:latest -f Dockerfile .
+
+# Launch your instance
+docker run --name apprise \
+   -p 8000:8000 \
+   -d  apprise/local:latest
+```
 A `docker-compose.yml` file is already set up to grant you an instant production ready simulated environment:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,23 @@
-django
+##
+## Apprise Backend Installation
+##
+## You should only have 1 of the 3 items uncommented below.
+
+## 1. Uncomment the below line to pull the main branch of Apprise:
+# apprise @ git+https://github.com/caronc/apprise
+
+## 2. Uncomment the below line instead if you wish to focus on a tag:
+# apprise @ git+https://github.com/caronc/apprise@custom-tag-or-version
+
+## 3. The below grabs our stable version (generally the best choice):
 apprise == 1.4.5
+
+## Apprise API Minimum Requirements
+django
 gevent
 gunicorn
 
-# 3rd party service support
+## 3rd Party Service support
 paho-mqtt
 gntp
 cryptography


### PR DESCRIPTION
## Description:
Just a small push that updates the documentation for users who want to pull/check out a different version of Apprise outside of the stable version which is always the default.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] Tests added
