### PR TITLE
Increased key length maximum size to 128 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ curl -X POST -d '{"tag":"leaders teamA, leaders teamB", "body":"meeting now"}' \
 
 ### API Notes
 
-- `{KEY}` must be 1-64 alphanumeric characters in length. In addition to this, the underscore (`_`) and dash (`-`) are also accepted.
+- `{KEY}` must be 1-128 alphanumeric characters in length. In addition to this, the underscore (`_`) and dash (`-`) are also accepted.
+  - Consider using keys like `sha1`, `sha512`, `uuid`, etc to secure shared namespaces if you wish to open your platform to others. Or keep it simple in a controlled environment and just use the default string `apprise` as your key (and as illustrated in the examples above).
 - Specify the `Content-Type` of `application/json` to use the JSON support otherwise the default expected format is `application/x-www-form-urlencoded` (whether it is specified or not).
 - There is no authentication (or SSL encryption) required to use this API; this is by design. The intention here is to be a light-weight and fast micro-service.
 - There are no additional dependencies (such as database requirements, etc) should you choose to use the optional persistent store (mounted as `/config`).
@@ -323,6 +324,7 @@ pip install -r dev-requirements.txt -r requirements.txt
 # Run a dev server (debug mode) accessible from your browser at:
 # -> http://localhost:8000/
 ./manage.py runserver
+
 ```
 
 Some other useful development notes:

--- a/apprise_api/api/urls.py
+++ b/apprise_api/api/urls.py
@@ -30,27 +30,27 @@ urlpatterns = [
         r'^$',
         views.WelcomeView.as_view(), name='welcome'),
     re_path(
-        r'^details/?',
+        r'^details/?$',
         views.DetailsView.as_view(), name='details'),
     re_path(
-        r'^cfg/(?P<key>[\w_-]{1,64})/?',
+        r'^cfg/(?P<key>[\w_-]{1,128})/?$',
         views.ConfigView.as_view(), name='config'),
     re_path(
-        r'^add/(?P<key>[\w_-]{1,64})/?',
+        r'^add/(?P<key>[\w_-]{1,128})/?$',
         views.AddView.as_view(), name='add'),
     re_path(
-        r'^del/(?P<key>[\w_-]{1,64})/?',
+        r'^del/(?P<key>[\w_-]{1,128})/?$',
         views.DelView.as_view(), name='del'),
     re_path(
-        r'^get/(?P<key>[\w_-]{1,64})/?',
+        r'^get/(?P<key>[\w_-]{1,128})/?$',
         views.GetView.as_view(), name='get'),
     re_path(
-        r'^notify/(?P<key>[\w_-]{1,64})/?',
+        r'^notify/(?P<key>[\w_-]{1,128})/?$',
         views.NotifyView.as_view(), name='notify'),
     re_path(
-        r'^notify/?',
+        r'^notify/?$',
         views.StatelessNotifyView.as_view(), name='s_notify'),
     re_path(
-        r'^json/urls/(?P<key>[\w_-]{1,64})/?',
+        r'^json/urls/(?P<key>[\w_-]{1,128})/?$',
         views.JsonUrlView.as_view(), name='json_urls'),
 ]


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs n/a

Increased key length size from 64 characters to 128.  Also fixed a bug enforcing that keys specified are ignored if longer.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
