### PR TITLE
Fix expiry date in theme set-cookie

### DIFF
--- a/apprise_api/core/middleware/theme.py
+++ b/apprise_api/core/middleware/theme.py
@@ -78,7 +78,7 @@ class AutoThemeMiddleware:
             datetime.timedelta(seconds=max_age)
 
         # Set our cookie
-        response.set_cookie('theme', theme, expires=expires.utctimetuple())
+        response.set_cookie('theme', theme, expires=expires)
 
         # return our response
         return response


### PR DESCRIPTION
## Description:

The theme cookie has an invalid _expires_ date:

```
Set-Cookie:  theme=light; expires=time.struct_time(tm_year=2024, tm_mon=10, tm_mday=19, tm_hour=9, tm_min=22, tm_sec=51, tm_wday=5, tm_yday=293, tm_isdst=0); Path=/
```

With fix:

```
Set-Cookie:  theme=light; expires=Sat, 19 Oct 2024 09:22:58 GMT; Max-Age=31536000; Path=/
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] Tests added
