### PR TITLE
Fix: Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG ARCH
-FROM ${ARCH}python:3.11-slim
+FROM python:3.11-slim as base
 
 # set version label
 ARG BUILD_DATE
@@ -14,20 +13,56 @@ ENV APPRISE_CONFIG_DIR /config
 ENV APPRISE_ATTACH_DIR /attach
 ENV APPRISE_PLUGIN_PATHS /plugin
 
+FROM base as builder
+
+WORKDIR /build/
+
 # Install nginx, supervisord, and cryptography dependencies
-RUN apt-get update -qq && \
-    apt-get install -y -qq nginx supervisor git curl \
-    build-essential libffi-dev libssl-dev pkg-config python3-dev
+RUN set -eux && \
+    echo "Installing build dependencies" && \
+        apt-get update -qq && \
+        apt-get install -y -qq \
+            curl \
+            build-essential \
+            libffi-dev \
+            libssl-dev \
+            pkg-config && \
+    echo "Updating pip and getting requirements to build" && \
+        # Cryptography documents that the latest version of pip3 must always be used
+        python3 -m pip install --upgrade \
+            pip \
+            wheel && \
+    echo "Installing latest rustc" && \
+        # Pull in bleeding edge of rust to keep up with cryptography build requirements
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
+        . "$HOME/.cargo/env" && \
+    echo "Buildingcryptography" && \
+        python3 -m pip wheel \
+            --no-binary cryptography \
+            cryptography
 
-# Cryptography documents that the latest version of pip3 must always be used
-RUN pip3 install --upgrade pip
-
-# Pull in bleeding edge of rust to keep up with cryptography build requirements
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+FROM base as runtime
 
 # Install requirements and gunicorn
 COPY ./requirements.txt /etc/requirements.txt
-RUN . "$HOME/.cargo/env" && pip3 install --no-cache-dir -q -r /etc/requirements.txt gunicorn --no-binary cryptography
+COPY --from=builder /build/*.whl .
+RUN set -eux && \
+    echo "Installing cryptography" && \
+        pip3 install *.whl && \
+    echo "Installing python requirements" && \
+        pip3 install --no-cache-dir -q -r /etc/requirements.txt gunicorn supervisor && \
+    echo "Installing nginx" && \
+        apt-get update -qq && \
+        apt-get install -y -qq \
+            nginx && \
+    echo "Cleaning up" && \
+        apt-get --yes autoremove --purge && \
+        apt-get clean --yes && \
+        rm --recursive --force --verbose /var/lib/apt/lists/* && \
+        rm --recursive --force --verbose /tmp/* && \
+        rm --recursive --force --verbose /var/tmp/* && \
+        rm --recursive --force --verbose /var/cache/apt/archives/* && \
+        truncate --size 0 /var/log/*log
 
 # Copy our static content in place
 COPY apprise_api/static /usr/share/nginx/html/s/
@@ -38,12 +73,6 @@ WORKDIR /opt/apprise
 # Copy over Apprise API
 COPY apprise_api/ webapp
 
-# Cleanup
- RUN . "$HOME/.cargo/env" && rustup self uninstall -y && \
-     apt-get remove -y -qq curl build-essential libffi-dev libssl-dev python3-dev pkg-config && \
-     apt-get clean autoclean && \
-     apt-get autoremove --yes && \
-         rm -rf /var/lib/{apt,dpkg,cache,log}/
 #
 # # Configuration Permissions (to run nginx as a non-root user)
 RUN umask 0002 && \
@@ -56,4 +85,4 @@ VOLUME /config
 VOLUME /attach
 VOLUME /plugin
 EXPOSE 8000
-CMD ["/usr/bin/supervisord", "-c", "/opt/apprise/webapp/etc/supervisord.conf"]
+CMD ["/usr/local/bin/supervisord", "-c", "/opt/apprise/webapp/etc/supervisord.conf"]


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** None

Reduces the Docker image compressed size to about 10% of the original size.  In short, the cleanup was not actually doing anything, as it happens on a different image layer from where the files being removed were added.

The `builder` stage is now responsible for producing the wheel for `cryptography`.  It also installs the minimal profile from rustup, for a slight speed up as well.  No cleanup is necessary here, as it is discarded when done

The `runtime` installs only the necessary packages and consumes the built wheel.  `aptget` leftovers are properly cleaned up in the same layer.

Everything else related to the application itself remains unchanged and running the image locally seems to work, serving the dashboard and such.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] Tests added
