### PR TITLE
Services are now sorted in a case-insensitive manner

### DIFF
--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -172,7 +172,7 @@ class DetailsView(View):
 
         # Sort our result set
         details['schemas'] = sorted(
-            details['schemas'], key=lambda i: str(i['service_name']))
+            details['schemas'], key=lambda i: str(i['service_name']).upper())
 
         # Return our content
         return render(request, self.template_name, {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

The primary reason for this was services like `ntfy` were showing up at the bottom of the list and not inline with the other services starting with `N`.  

The list is now sorted in a case insensitive manner for an improved presentation.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
