### PR TITLE
allow empty body when attachment is provided

### DIFF
--- a/apprise_api/api/forms.py
+++ b/apprise_api/api/forms.py
@@ -136,6 +136,7 @@ class NotifyForm(forms.Form):
         widget=forms.Textarea(
             attrs={'placeholder': _('Define your message body here...')}),
         max_length=apprise.NotifyBase.body_maxlen,
+        required=False,
     )
 
     # Attachment Support

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -83,6 +83,26 @@ class NotifyTests(SimpleTestCase):
         mock_notify.reset_mock()
 
         # Preare our form data
+        form_data = {}
+        attach_data = {
+            'attachment': SimpleUploadedFile(
+                "attach.txt", b"content here", content_type="text/plain")
+        }
+
+        # At a minimum, just an attachment is required
+        form = NotifyForm(form_data, attach_data)
+        assert form.is_valid()
+
+        # Send our notification
+        response = self.client.post(
+            '/notify/{}'.format(key), form.cleaned_data)
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Preare our form data
         form_data = {
             'body': 'test notifiction',
         }

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -691,7 +691,7 @@ class NotifyView(View):
             content['title'] = request.GET['title']
 
         # Some basic error checking
-        if not content.get('body') or \
+        if not content.get('body') and not attach or \
                 content.get('type', apprise.NotifyType.INFO) \
                 not in apprise.NOTIFY_TYPES:
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #<!--apprise issue number goes here-->

When an attachment is provided, `body` should be optional. At least this is how the command-line works.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
