### PR TITLE
Support `tags` GET and POST arg in addition to `tag`

### DIFF
--- a/apprise_api/api/forms.py
+++ b/apprise_api/api/forms.py
@@ -152,6 +152,14 @@ class NotifyForm(forms.Form):
         required=False,
     )
 
+    # Allow support for tags keyword in addition to tag; the 'tag' field will always take priority over this
+    # however adding `tags` gives the user more flexibilty to use either/or keyword
+    tags = forms.CharField(
+        label=_('Tags'),
+        widget=forms.HiddenInput(),
+        required=False,
+    )
+
     def clean_type(self):
         """
         We just ensure there is a type always set


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #162 
- Added `tags` kw support
- Improved logging (addresses #158)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
