### PR TITLE
Stateless GET Parameter Support

### DIFF
--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -373,6 +373,33 @@ class StatelessNotifyTests(SimpleTestCase):
         assert mock_notify.call_count == 1
 
     @mock.patch('apprise.Apprise.notify')
+    def test_notify_with_get_parameters(self, mock_notify):
+        """
+        Test sending a simple notification using JSON with GET
+        parameters
+        """
+
+        # Set our return value
+        mock_notify.return_value = True
+
+        # Preare our JSON data
+        json_data = {
+            'urls': 'json://user@my.domain.ca',
+            'body': 'test notifiction',
+        }
+
+        # Send our notification as a JSON object
+        response = self.client.post(
+            '/notify/?title=my%20title&format=text&type=info',
+            data=json.dumps(json_data),
+            content_type='application/json',
+        )
+
+        # Still supported
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+
+    @mock.patch('apprise.Apprise.notify')
     def test_notify_by_loaded_urls_with_json(self, mock_notify):
         """
         Test sending a simple notification using JSON

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1039,6 +1039,27 @@ class StatelessNotifyView(View):
             # defined
             content['urls'] = settings.APPRISE_STATELESS_URLS
 
+        #
+        # Allow 'format' value to be specified as part of the URL
+        # parameters if not found otherwise defined.
+        #
+        if not content.get('format') and 'format' in request.GET:
+            content['format'] = request.GET['format']
+
+        #
+        # Allow 'type' value to be specified as part of the URL parameters
+        # if not found otherwise defined.
+        #
+        if not content.get('type') and 'type' in request.GET:
+            content['type'] = request.GET['type']
+
+        #
+        # Allow 'title' value to be specified as part of the URL parameters
+        # if not found otherwise defined.
+        #
+        if not content.get('title') and 'title' in request.GET:
+            content['title'] = request.GET['title']
+
         # Some basic error checking
         if not content.get('body') or \
                 content.get('type', apprise.NotifyType.INFO) \


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

GET parameters `title`, `type`, and `format` can be passed on the URL to provide default values if nothing in the message body exists (this is already how Stateful Apprise POSTs are handled).  This is merely making both consistent.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
