### PR TITLE
Support 'attach' keyword (alias of 'attachment')

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ curl -X POST -d 'urls=mailto://user:pass@gmail.com' \
 curl -X POST -d '{"urls": "mailto://user:pass@gmail.com", "body":"test message"}' \
     -H "Content-Type: application/json" \
     http://localhost:8000/notify
+
+# attach= is an alias of attachment=
+# Send a notification with a URL based attachment
+curl -X POST \
+    -F 'urls=mailto://user:pass@gmail.com' \
+    -F attach=attach=https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-logo.png \
+    http://localhost:8000/notify
 ```
 
 You can also send notifications that are URLs.  Apprise will download the item so that it can send it along to all end points that should be notified about it.
@@ -251,6 +258,13 @@ curl -X POST \
     -F 'body=test message' \
     -F attach1=@Screenshot-1.png \
     -F attach2=@/my/path/to/Apprise.doc \
+    http://localhost:8000/notify/abc123
+
+# attach= is an alias of attachment=
+# Send a notification with a URL based attachment
+curl -X POST \
+    -F 'urls=mailto://user:pass@gmail.com' \
+    -F attach=attach=https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-logo.png \
     http://localhost:8000/notify/abc123
 ```
 

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -115,6 +115,12 @@
 				&nbsp;&nbsp;&nbsp;&nbsp;-F attach1=@Screenshot-1.png \<br/>
 				&nbsp;&nbsp;&nbsp;&nbsp;-F attach2=@/my/path/to/Apprise.doc \<br/>
 				&nbsp;&nbsp;&nbsp;&nbsp;http{% if request.is_secure %}s{% endif %}://{{request.META.HTTP_HOST}}{{BASE_URL}}/notify/<em>{{key}}</em></code></pre>
+        {% blocktrans %}Sends a notification to our endpoints with an attachment{% endblocktrans %}
+	      <pre><code class="bash">
+        curl -X POST \<br/>
+        &nbsp;&nbsp;&nbsp;&nbsp;-F "tag=all" \ <br/>
+        &nbsp;&nbsp;&nbsp;&nbsp;-F "attach=https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-logo.png" \ <br/>
+        &nbsp;&nbsp;&nbsp;&nbsp;"{{request.scheme}}://{{request.META.HTTP_HOST}}{{BASE_URL}}/notify/<em>{{key}}</em>"</code></pre>
         </p>
       </div>
       <div class="section">

--- a/apprise_api/api/templates/welcome.html
+++ b/apprise_api/api/templates/welcome.html
@@ -99,6 +99,11 @@
                     &nbsp;&nbsp;&nbsp;&nbsp;-F attach2=@Screenshot-2.png \ <br/>
 										&nbsp;&nbsp;&nbsp;&nbsp;"{{request.scheme}}://{{request.META.HTTP_HOST}}{{BASE_URL}}/notify/"
                   </code></pre>
+	                <pre><code class="bash">
+                    # {% blocktrans %}Send an web based file attachment to a <a href="https://github.com/caronc/apprise/wiki/Notify_discord" target="_blank">Discord</a> server:{% endblocktrans %}<br/>
+                    curl -X POST -F 'urls=discord://credentials' \<br/>
+                    &nbsp;&nbsp;&nbsp;&nbsp;-F "attach=https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-logo.png" \ <br/>
+                    &nbsp;&nbsp;&nbsp;&nbsp;"{{request.scheme}}://{{request.META.HTTP_HOST}}{{BASE_URL}}/notify/"</code></pre>
                 </div>
               </li>
               <li>
@@ -492,6 +497,12 @@
                         &nbsp;&nbsp;&nbsp;&nbsp;-F "tag=all" \ <br/>
                         &nbsp;&nbsp;&nbsp;&nbsp;-F "body=test body" \ <br/>
                         &nbsp;&nbsp;&nbsp;&nbsp;-F "title=test title" \ <br/>
+                        &nbsp;&nbsp;&nbsp;&nbsp;"{{request.scheme}}://{{request.META.HTTP_HOST}}{{BASE_URL}}/notify/<em>{{key}}</em>"</code></pre>
+	                    <pre><code class="bash">
+                        # {% blocktrans %}Sends a notification to our endpoints with an attachment{% endblocktrans %}<br/>
+                        curl -X POST \<br/>
+                        &nbsp;&nbsp;&nbsp;&nbsp;-F "tag=all" \ <br/>
+                        &nbsp;&nbsp;&nbsp;&nbsp;-F "attach=https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-logo.png" \ <br/>
                         &nbsp;&nbsp;&nbsp;&nbsp;"{{request.scheme}}://{{request.META.HTTP_HOST}}{{BASE_URL}}/notify/<em>{{key}}</em>"</code></pre>
                     <pre><code class="bash">
 								    # {% blocktrans %}Notifies all URLs assigned the <em>devops</em> tag{% endblocktrans %}<br/>

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -1043,11 +1043,9 @@ class NotifyTests(SimpleTestCase):
 
         json_data = {
             'body': 'test message',
-            'format': None,
         }
 
         # Same results for any empty string:
-        json_data['format'] = ''
         response = self.client.post(
             '/notify/{}'.format(key),
             data=json.dumps(json_data),

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -847,6 +847,22 @@ class NotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Preare our form data
+        form_data = {
+            'body': 'test notifiction',
+            'attach': 'https://localhost/invalid/path/to/image.png',
+        }
+
+        # Send our notification
+        response = self.client.post(
+            '/notify/{}'.format(key), form_data)
+        # We fail because we couldn't retrieve our attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
     @mock.patch('apprise.Apprise.notify')
     def test_notify_by_loaded_urls_with_json(self, mock_notify):
         """
@@ -998,8 +1014,37 @@ class NotifyTests(SimpleTestCase):
         assert response.status_code == 200
         assert mock_notify.call_count == 1
 
+
         # Reset our mock object
         mock_notify.reset_mock()
+
+        # If an empty format is specified, it is accepted and
+        # no imput format is specified
+        json_data = {
+            'body': 'test message',
+            'format': None,
+            'attach': 'https://localhost/invalid/path/to/image.png',
+        }
+
+        # Test case with format changed
+        response = self.client.post(
+            '/notify/{}'.format(key),
+            data=json.dumps(json_data),
+            content_type='application/json',
+        )
+
+        # We failed to send notification because we couldn't fetch the
+        # attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        json_data = {
+            'body': 'test message',
+            'format': None,
+        }
 
         # Same results for any empty string:
         json_data['format'] = ''

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -250,6 +250,50 @@ class StatelessNotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Preare our form data (support attach keyword)
+        form_data = {
+            'body': 'test notifiction',
+            'urls': ', '.join([
+                'mailto://user:pass@hotmail.com',
+                'mailto://user:pass@gmail.com',
+            ]),
+            'attach': 'https://localhost/invalid/path/to/image.png',
+        }
+
+        # Send our notification
+        response = self.client.post('/notify', form_data)
+        # We fail because we couldn't retrieve our attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Preare our json data (and support attach keyword as alias)
+        json_data = {
+            'body': 'test notifiction',
+            'urls': ', '.join([
+                'mailto://user:pass@hotmail.com',
+                'mailto://user:pass@gmail.com',
+            ]),
+            'attach': 'https://localhost/invalid/path/to/image.png',
+        }
+
+        # Same results
+        response = self.client.post(
+            '/notify/',
+            data=json.dumps(json_data),
+            content_type='application/json',
+        )
+
+        # We fail because we couldn't retrieve our attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+
     @override_settings(APPRISE_RECURSION_MAX=1)
     @mock.patch('apprise.Apprise.notify')
     def test_stateless_notify_recursion(self, mock_notify):

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -293,7 +293,6 @@ class StatelessNotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
-
     @override_settings(APPRISE_RECURSION_MAX=1)
     @mock.patch('apprise.Apprise.notify')
     def test_stateless_notify_recursion(self, mock_notify):

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -610,9 +610,19 @@ class NotifyView(View):
 
         # Handle Attachments
         attach = None
-        if not content.get('attachment') and 'attachment' in request.POST:
-            # Acquire attachments to work with them
-            content['attachment'] = request.POST.getlist('attachment')
+        if not content.get('attachment'):
+            if 'attachment' in request.POST:
+                # Acquire attachments to work with them
+                content['attachment'] = request.POST.getlist('attachment')
+
+            elif 'attach' in request.POST:
+                # Acquire kw (alias) attach to work with them
+                content['attachment'] = request.POST.getlist('attach')
+
+            elif content.get('attach'):
+                # Acquire kw (alias) attach from payload to work with
+                content['attachment'] = content['attach']
+                del content['attach']
 
         if 'attachment' in content or request.FILES:
             try:
@@ -1029,7 +1039,7 @@ class StatelessNotifyView(View):
             logger.warning(
                 'NOTIFY - %s - Invalid FORM Payload provided',
                 request.META['REMOTE_ADDR'])
-    
+
             return HttpResponse(
                 _('Bad FORM Payload provided.'),
                 status=ResponseCode.bad_request)
@@ -1148,9 +1158,19 @@ class StatelessNotifyView(View):
 
         # Handle Attachments
         attach = None
-        if not content.get('attachment') and 'attachment' in request.POST:
-            # Acquire attachments to work with them
-            content['attachment'] = request.POST.getlist('attachment')
+        if not content.get('attachment'):
+            if 'attachment' in request.POST:
+                # Acquire attachments to work with them
+                content['attachment'] = request.POST.getlist('attachment')
+
+            elif 'attach' in request.POST:
+                # Acquire kw (alias) attach to work with them
+                content['attachment'] = request.POST.getlist('attach')
+
+            elif content.get('attach'):
+                # Acquire kw (alias) attach from payload to work with
+                content['attachment'] = content['attach']
+                del content['attach']
 
         if 'attachment' in content or request.FILES:
             try:
@@ -1158,6 +1178,11 @@ class StatelessNotifyView(View):
                     content.get('attachment'), request.FILES)
 
             except (TypeError, ValueError):
+                # Invalid entry found in list
+                logger.warning(
+                    'NOTIFY - %s - Bad attachment specified',
+                    request.META['REMOTE_ADDR'])
+
                 return HttpResponse(
                     _('Bad attachment'),
                     status=ResponseCode.bad_request)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #157

- Add `attach` as an alias of `attachment` to make the Apprise API a bit easier to use
- Improved Web API Documentation / Examples
- Updated `README.md` to also give examples

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
