### PR TITLE
bugfix: APPRISE_ATTACH_SIZE correctly manages attachment size

### DIFF
--- a/apprise_api/api/tests/test_attachment.py
+++ b/apprise_api/api/tests/test_attachment.py
@@ -121,11 +121,12 @@ class AttachmentTests(SimpleTestCase):
 
         # Test a case where our attachment exceeds the maximum size we allow
         # for
-        with override_settings(APPRISE_MAX_ATTACHMENT_SIZE=1):
+        with override_settings(APPRISE_ATTACH_SIZE=1):
             files_request = {
                 'file1': SimpleUploadedFile(
                     "attach.txt",
-                    b"some content more then 1 byte in length to pass along.",
+                    # More then 1 MB in size causing error to trip
+                    ("content" * 1024 * 1024).encode('utf-8'),
                     content_type="text/plain")
             }
             with self.assertRaises(ValueError):
@@ -324,9 +325,10 @@ class AttachmentTests(SimpleTestCase):
 
         # Test a case where our attachment exceeds the maximum size we allow
         # for
-        with override_settings(APPRISE_MAX_ATTACHMENT_SIZE=1):
+        with override_settings(APPRISE_ATTACH_SIZE=1):
+            # More then 1 MB in size causing error to trip
             attachment_payload = \
-                b"some content more then 1 byte in length to pass along."
+                ("content" * 1024 * 1024).encode('utf-8')
             with self.assertRaises(ValueError):
                 parse_attachments(attachment_payload, {})
 

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -338,8 +338,8 @@ def parse_attachments(attachment_payload, files_request):
                 #
                 # Some Validation
                 #
-                if settings.APPRISE_MAX_ATTACHMENT_SIZE > 0 and \
-                        attachment.size > settings.APPRISE_MAX_ATTACHMENT_SIZE:
+                if settings.APPRISE_ATTACH_SIZE > 0 and \
+                        attachment.size > settings.APPRISE_ATTACH_SIZE:
                     raise ValueError(
                         "attachment %s's filesize is to large" % filename)
 
@@ -387,8 +387,8 @@ def parse_attachments(attachment_payload, files_request):
             #
             # Some Validation
             #
-            if settings.APPRISE_MAX_ATTACHMENT_SIZE > 0 and \
-                    attachment.size > settings.APPRISE_MAX_ATTACHMENT_SIZE:
+            if settings.APPRISE_ATTACH_SIZE > 0 and \
+                    attachment.size > settings.APPRISE_ATTACH_SIZE:
                 raise ValueError(
                     "attachment %s's filesize is to large" % filename)
 

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -629,11 +629,11 @@ class NotifyView(View):
                 attach = parse_attachments(
                     content.get('attachment'), request.FILES)
 
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as e:
                 # Invalid entry found in list
                 logger.warning(
-                    'NOTIFY - %s - Bad attachment specified',
-                    request.META['REMOTE_ADDR'])
+                    'NOTIFY - %s - Bad attachment: %s',
+                    request.META['REMOTE_ADDR'], str(e))
 
                 return HttpResponse(
                     _('Bad attachment'),
@@ -1177,11 +1177,11 @@ class StatelessNotifyView(View):
                 attach = parse_attachments(
                     content.get('attachment'), request.FILES)
 
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as e:
                 # Invalid entry found in list
                 logger.warning(
-                    'NOTIFY - %s - Bad attachment specified',
-                    request.META['REMOTE_ADDR'])
+                    'NOTIFY - %s - Bad attachment: %s',
+                    request.META['REMOTE_ADDR'], str(e))
 
                 return HttpResponse(
                     _('Bad attachment'),

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -146,7 +146,7 @@ APPRISE_CONFIG_DIR = os.environ.get(
 APPRISE_ATTACH_DIR = os.environ.get(
     'APPRISE_ATTACH_DIR', os.path.join(BASE_DIR, 'var', 'attach'))
 
-# The file attachment size allowed by the API
+# The maximum file attachment size allowed by the API (defined in MB)
 APPRISE_ATTACH_SIZE = int(os.environ.get('APPRISE_ATTACH_SIZE', 200)) * 1048576
 
 # When set Apprise API Locks itself down so that future (configuration)
@@ -205,8 +205,3 @@ APPRISE_PLUGIN_PATHS = os.environ.get(
 # Define the number of attachments that can exist as part of a payload
 # Setting this to zero disables the limit
 APPRISE_MAX_ATTACHMENTS = int(os.environ.get('APPRISE_MAX_ATTACHMENTS', 6))
-
-# Defines the maximum size each attachment can be
-# 8388608 == 8MB
-APPRISE_MAX_ATTACHMENT_SIZE = int(
-    os.environ.get('APPRISE_MAX_ATTACHMENT_SIZE', 8388608))


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #176 

The `APPRISE_ATTACH_SIZE` global correctly handles attachment sizes again (defined in MB) and defaults to `200`.

Previous to this there was another variable (undocumented) fixing this value to 8MB.

This PR also makes server side logging a bit more explanatory as to why the attachment was not processed (should this be the case)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] Tests added
