### PR TITLE
Added payload mapper

### DIFF
--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+from api.forms import NotifyForm
+
+# import the logging library
+import logging
+
+# Get an instance of a logger
+logger = logging.getLogger('django')
+
+
+def remap_fields(rules, payload):
+    """
+    Remaps fields in the payload provided based on the rules provided
+
+    The key value of the dictionary identifies the payload key type you
+    wish to alter.  If there is no value defined, then the entry is removed
+
+    If there is a value provided, then it's key is swapped into the new key
+    provided.
+
+    The purpose of this function is to allow people to re-map the fields
+    that are being posted to the Apprise API before hand.  Mapping them
+    can allow 3rd party programs that post 'subject' and 'content' to
+    be remapped to say 'title' and 'body' respectively
+
+    """
+
+    # First generate our allowed keys; only these can be mapped
+    allowed_keys = set(NotifyForm().fields.keys())
+    for _key, value in rules.items():
+
+        key = _key.lower()
+        if key in payload and not value:
+            # Remove element
+            del payload[key]
+            continue
+
+        vkey = value.lower()
+        if vkey in allowed_keys:
+            if key not in allowed_keys or vkey not in payload:
+                # replace
+                payload[vkey] = payload[key]
+                del payload[key]
+
+            elif vkey in payload:
+                # swap
+                _tmp = payload[vkey]
+                payload[vkey] = payload[key]
+                payload[key] = _tmp
+
+        else:
+            # store
+            payload[key] = value
+
+    return True

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -31,7 +31,7 @@ import logging
 logger = logging.getLogger('django')
 
 
-def remap_fields(rules, payload):
+def remap_fields(rules, payload, form=None):
     """
     Remaps fields in the payload provided based on the rules provided
 
@@ -48,8 +48,11 @@ def remap_fields(rules, payload):
 
     """
 
-    # First generate our allowed keys; only these can be mapped
-    allowed_keys = set(NotifyForm().fields.keys())
+    # Prepare our Form (identifies our expected keys)
+    form = NotifyForm() if form is None else form
+
+    # First generate our expected keys; only these can be mapped
+    expected_keys = set(form.fields.keys())
     for _key, value in rules.items():
 
         key = _key.lower()
@@ -59,8 +62,8 @@ def remap_fields(rules, payload):
             continue
 
         vkey = value.lower()
-        if vkey in allowed_keys:
-            if key not in allowed_keys or vkey not in payload:
+        if vkey in expected_keys and key in payload:
+            if key not in expected_keys or vkey not in payload:
                 # replace
                 payload[vkey] = payload[key]
                 del payload[key]
@@ -71,8 +74,8 @@ def remap_fields(rules, payload):
                 payload[vkey] = payload[key]
                 payload[key] = _tmp
 
-        else:
-            # store
+        elif key in expected_keys or key in payload:
+            # assignment
             payload[key] = value
 
     return True

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -196,3 +196,31 @@ class NotifyPayloadMapper(SimpleTestCase):
             'format': 'markdown',
             'body': 'the message',
         }
+
+
+        #
+        # mapping of fields don't align - test 6
+        #
+        rules = {
+            'payload': 'body',
+            'fmt': 'format',
+            'extra': 'tag',
+        }
+        payload = {
+            'format': 'markdown',
+            'type': 'info',
+            'title': '',
+            'body': '## test notifiction',
+            'attachment': None,
+            'tag': 'general',
+            'tags': '',
+        }
+
+        # Make a copy of our original payload
+        payload_orig = payload.copy()
+
+        # Map our fields
+        remap_fields(rules, payload)
+
+        # There are no rules applied since nothing aligned
+        assert payload == payload_orig

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+from django.test import SimpleTestCase
+from ..payload_mapper import remap_fields
+
+
+class NotifyPayloadMapper(SimpleTestCase):
+    """
+    Test Payload Mapper
+    """
+
+    def test_remap_fields(self):
+        """
+        Test payload re-mapper
+        """
+
+        #
+        # No rules defined
+        #
+        rules = {}
+        payload = {
+            'format': 'markdown',
+            'title': 'title',
+            'body': '# body',
+        }
+        payload_orig = payload.copy()
+
+        # Map our fields
+        remap_fields(rules, payload)
+
+        # no change is made
+        assert payload == payload_orig
+
+        #
+        # rules defined - test 1
+        #
+        rules = {
+            # map 'as' to 'format'
+            'as': 'format',
+            # map 'subject' to 'title'
+            'subject': 'title',
+            # map 'content' to 'body'
+            'content': 'body',
+            # 'missing' is an invalid entry so this will be skipped
+            'unknown': 'missing',
+
+            # Empty field
+            'attachment': '',
+
+            # Garbage is an field that can be removed since it doesn't
+            # conflict with the form
+            'garbage': '',
+
+            # Tag
+            'tag': 'test',
+        }
+        payload = {
+            'as': 'markdown',
+            'subject': 'title',
+            'content': '# body',
+            'tag': '',
+            'unknown': 'hmm',
+            'attachment': '',
+            'garbage': '',
+        }
+
+        # Map our fields
+        remap_fields(rules, payload)
+
+        # Our field mappings have taken place
+        assert payload == {
+            'tag': 'test',
+            'unknown': 'missing',
+            'format': 'markdown',
+            'title': 'title',
+            'body': '# body',
+        }
+
+        #
+        # rules defined - test 2
+        #
+        rules = {
+            #
+            # map 'content' to 'body'
+            'content': 'body',
+            # a double mapping to body will trigger an error
+            'message': 'body',
+            # Swapping fields
+            'body': 'another set of data',
+        }
+        payload = {
+            'as': 'markdown',
+            'subject': 'title',
+            'content': '# content body',
+            'message': '# message body',
+            'body': 'another set of data',
+        }
+
+        # Map our fields
+        remap_fields(rules, payload)
+
+        # Our information gets swapped
+        assert payload == {
+            'as': 'markdown',
+            'subject': 'title',
+            'body': 'another set of data',
+        }
+
+        #
+        # swapping fields - test 3
+        #
+        rules = {
+            #
+            # map 'content' to 'body'
+            'title': 'body',
+        }
+        payload = {
+            'format': 'markdown',
+            'title': 'body',
+            'body': '# title',
+        }
+
+        # Map our fields
+        remap_fields(rules, payload)
+
+        # Our information gets swapped
+        assert payload == {
+            'format': 'markdown',
+            'title': '# title',
+            'body': 'body',
+        }
+
+        #
+        # swapping fields - test 4
+        #
+        rules = {
+            #
+            # map 'content' to 'body'
+            'title': 'body',
+        }
+        payload = {
+            'format': 'markdown',
+            'title': 'body',
+        }
+
+        # Map our fields
+        remap_fields(rules, payload)
+
+        # Our information gets swapped
+        assert payload == {
+            'format': 'markdown',
+            'body': 'body',
+        }
+
+        #
+        # swapping fields - test 5
+        #
+        rules = {
+            #
+            # map 'content' to 'body'
+            'content': 'body',
+        }
+        payload = {
+            'format': 'markdown',
+            'content': 'the message',
+            'body': 'to-be-replaced',
+        }
+
+        # Map our fields
+        remap_fields(rules, payload)
+
+        # Our information gets swapped
+        assert payload == {
+            'format': 'markdown',
+            'body': 'the message',
+        }

--- a/apprise_api/api/tests/test_stateful_notify.py
+++ b/apprise_api/api/tests/test_stateful_notify.py
@@ -27,6 +27,7 @@ from django.test.utils import override_settings
 from unittest.mock import patch, Mock
 from ..forms import NotifyForm
 from ..utils import ConfigCache
+from json import dumps
 import os
 import re
 import apprise
@@ -107,7 +108,7 @@ class StatefulNotifyTests(SimpleTestCase):
             assert len(entries) == 3
 
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 'tag': 'general',
             }
@@ -128,7 +129,40 @@ class StatefulNotifyTests(SimpleTestCase):
             mock_post.reset_mock()
 
             form_data = {
-                'body': '## test notifiction',
+                'payload': '## test notification',
+                'fmt': apprise.NotifyFormat.MARKDOWN,
+                'extra': 'general',
+            }
+
+            # We sent the notification successfully (use our rule mapping)
+            # FORM
+            response = self.client.post(
+                f'/notify/{key}/?:payload=body&:fmt=format&:extra=tag',
+                form_data)
+            assert response.status_code == 200
+            assert mock_post.call_count == 1
+
+            mock_post.reset_mock()
+
+            form_data = {
+                'payload': '## test notification',
+                'fmt': apprise.NotifyFormat.MARKDOWN,
+                'extra': 'general',
+            }
+
+            # We sent the notification successfully (use our rule mapping)
+            # JSON
+            response = self.client.post(
+                f'/notify/{key}/?:payload=body&:fmt=format&:extra=tag',
+                dumps(form_data),
+                content_type="application/json")
+            assert response.status_code == 200
+            assert mock_post.call_count == 1
+
+            mock_post.reset_mock()
+
+            form_data = {
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 'tag': 'no-on-with-this-tag',
             }
@@ -180,7 +214,7 @@ class StatefulNotifyTests(SimpleTestCase):
             assert len(entries) == 3
 
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
             }
 
@@ -204,7 +238,7 @@ class StatefulNotifyTests(SimpleTestCase):
             # Test tagging now
             #
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 'tag': 'general+json',
             }
@@ -226,7 +260,7 @@ class StatefulNotifyTests(SimpleTestCase):
             mock_post.reset_mock()
 
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 # Plus with space inbetween
                 'tag': 'general + json',
@@ -248,7 +282,7 @@ class StatefulNotifyTests(SimpleTestCase):
             mock_post.reset_mock()
 
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 # Space (AND)
                 'tag': 'general json',
@@ -269,7 +303,7 @@ class StatefulNotifyTests(SimpleTestCase):
             mock_post.reset_mock()
 
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 # Comma (OR)
                 'tag': 'general, devops',
@@ -351,7 +385,7 @@ class StatefulNotifyTests(SimpleTestCase):
 
         for tag in ('user1', 'user2'):
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 'tag': tag,
             }
@@ -374,7 +408,7 @@ class StatefulNotifyTests(SimpleTestCase):
 
         # Now let's notify by our group
         form_data = {
-            'body': '## test notifiction',
+            'body': '## test notification',
             'format': apprise.NotifyFormat.MARKDOWN,
             'tag': 'mygroup',
         }
@@ -448,7 +482,7 @@ class StatefulNotifyTests(SimpleTestCase):
 
         for tag in ('user1', 'user2'):
             form_data = {
-                'body': '## test notifiction',
+                'body': '## test notification',
                 'format': apprise.NotifyFormat.MARKDOWN,
                 'tag': tag,
             }
@@ -471,7 +505,7 @@ class StatefulNotifyTests(SimpleTestCase):
 
         # Now let's notify by our group
         form_data = {
-            'body': '## test notifiction',
+            'body': '## test notification',
             'format': apprise.NotifyFormat.MARKDOWN,
             'tag': 'mygroup',
         }

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -120,6 +120,39 @@ class StatelessNotifyTests(SimpleTestCase):
             # Reset our mock object
             mock_notify.reset_mock()
 
+            form_data = {
+                'payload': '## test notification',
+                'fmt': apprise.NotifyFormat.MARKDOWN,
+                'extra': 'mailto://user:pass@hotmail.com',
+            }
+
+            # We sent the notification successfully (use our rule mapping)
+            # FORM
+            response = self.client.post(
+                f'/notify/?:payload=body&:fmt=format&:extra=urls',
+                form_data)
+            assert response.status_code == 200
+            assert mock_notify.call_count == 1
+
+            mock_notify.reset_mock()
+
+            form_data = {
+                'payload': '## test notification',
+                'fmt': apprise.NotifyFormat.MARKDOWN,
+                'extra': 'mailto://user:pass@hotmail.com',
+            }
+
+            # We sent the notification successfully (use our rule mapping)
+            # JSON
+            response = self.client.post(
+                '/notify/?:payload=body&:fmt=format&:extra=urls',
+                json.dumps(form_data),
+                content_type="application/json")
+            assert response.status_code == 200
+            assert mock_notify.call_count == 1
+
+            mock_notify.reset_mock()
+
         # Long Filename
         attach_data = {
             'attachment': SimpleUploadedFile(


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #183

Added the ability to remap fields during a notification submission by using `:` (colon) in the GET args of the post.

For example, consider a situation where your server posts the following:
```json
{
    "content": "Message body",
    "subject": "Message title",
}
```

These fields can be mapped to what the Apprise API expects with the following URL:
```bash
curl -X POST   \
   -F "body=Test Message" \
   -F "tags=all"  \
   "http://localhost:8000/notify/apprise-api-key?:content=body&:subject=title"
```

The above identifies `:content=body` which tells the Apprise API to map the `content` entry to `body`, and `:subject` tells it to map `subject` to `title`.    Effectively, your payload looks like this now which is exactly what Apprise needed! :rocket: :
```json
{
    "body": "Message body",
    "title": "Message title",
}
```

The colon `:` prefix is the switch that starts the rule engine.  You can do 3 possible things with the rule engine:
1. `:existing_key=new_key`: Rename an existing key to one apprise wants
1. `:existing_key=`: By setting no value, the existing key is simply removed from the payload entirely
1. `:apprise_key=A value to give it`: You can also set an expected apprise key to a pre-generated string value.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
