### PR TITLE
improved LOG_LEVEL environment variable handling

### DIFF
--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -107,6 +107,8 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console'],
+            'level': os.environ.get(
+                'LOG_LEVEL', 'debug' if DEBUG else 'info').upper(),
         },
         'apprise': {
             'handlers': ['console'],


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #228

`LOG_LEVEL` previously only set the `apprise` handler to align with the environment variable set.  Updated to also set the `django` environment variable as well.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] Tests added
