### PR TITLE
IPV4_ONLY and IPV6_ONLY environment control added

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ The use of environment variables allow you to provide over-rides to default sett
 |--------------------- | ----------- |
 | `PUID` | The User ID you wish the Apprise instance under the hood to run as. The default is `1000` if not otherwise specified.
 | `PGID` | The Group ID you wish the Apprise instance under the hood to run as. The default is `1000` if not otherwise specified.
+| `IPV4_ONLY` | Force an all IPv4 only environment (default supports both IPV4 and IPv6).  Nothing is done if `IPV6_ONLY` is also set as this creates an ambigious setup.
+| `IPV6_ONLY` | Force an all IPv6 only environment (default supports both IPv4 and IPv6).  Nothing is done if `IPV4_ONLY` is also set as this creates an ambigious setup.
 | `APPRISE_DEFAULT_THEME` | Can be set to `light` or `dark`; it defaults to `light` if not otherwise provided.  The theme can be toggled from within the website as well.
 | `APPRISE_DEFAULT_CONFIG_ID` | Defaults to `apprise`.   This is the presumed configuration ID you always default to when accessing the configuration manager via the website.
 | `APPRISE_CONFIG_DIR` | Defines an (optional) persistent store location of all configuration files saved. By default:<br/> - Configuration is written to the `apprise_api/var/config` directory when just using the _Django_ `manage runserver` script. However for the path for the container is `/config`.

--- a/apprise_api/etc/nginx.conf
+++ b/apprise_api/etc/nginx.conf
@@ -42,8 +42,8 @@ http {
    client_body_in_file_only off;
 
    server {
-      listen      8000;
-      listen [::]:8000;
+      listen      8000; # IPv4 Support
+      listen [::]:8000; # IPv6 Support
 
       # Allow users to map to this file and provide their own custom
       # overrides such as

--- a/apprise_api/gunicorn.conf.py
+++ b/apprise_api/gunicorn.conf.py
@@ -38,10 +38,8 @@ pythonpath = '/opt/apprise/webapp'
 
 # bind to port 8000
 bind = [
-    # ipv4
-    '0.0.0.0:8000',
-    # ipv6
-    '[::]:8000'
+    '0.0.0.0:8000',  # IPv4 Support
+    '[::]:8000',  # IPv6 Support
 ]
 
 # Workers are relative to the number of CPU's provided by hosting server

--- a/apprise_api/supervisord-startup
+++ b/apprise_api/supervisord-startup
@@ -70,6 +70,22 @@ sed -i -e "s/^\(user[ \t]*=[ \t]*\).*$/\1$USER/g" \
 sed -i -e "s/^\(group[ \t]*=[ \t]*\).*$/\1$GROUP/g" \
    /opt/apprise/webapp/etc/supervisord.conf
 
+if [ "${IPV4_ONLY+x}" ] && [ "${IPV6_ONLY+x}" ]; then
+  echo -n "Warning: both IPV4_ONLY and IPV6_ONLY flags set; ambigious; no changes made."
+
+# Handle IPV4_ONLY flag
+elif [ "${IPV4_ONLY+x}" ]; then
+  echo -n "Enforcing Exclusive IPv4 environment... "
+  sed -ibak -e '/IPv6 Support/d' /opt/apprise/webapp/etc/nginx.conf /opt/apprise/webapp/gunicorn.conf.py && \
+     echo "Done." || echo "Failed!"
+
+# Handle IPV6_ONLY flag
+elif [ "${IPV6_ONLY+x}" ]; then
+  echo -n "Enforcing Exclusive IPv6 environment... "
+  sed -ibak -e '/IPv4 Support/d' /opt/apprise/webapp/etc/nginx.conf /opt/apprise/webapp/gunicorn.conf.py && \
+     echo "Done." || echo "Failed!"
+fi
+
 # Working directory
 cd /opt/apprise
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #211

Added 2 new environment variables that allow the exclusive enforcing of an IPv4 or IPv6 environment only.

* `IPV4_ONLY`: Eliminate any IPv6 configuration in place to run n an exclusive IPv4 mode
* `IPV6_ONLY`: Eliminate any IPv4 configuration in place to run in an exclusive IPv6 mode

For obvious reasons, it's ambigious to set both environment variables, so if this is detected, nothing is updated/changed within the docker environment.

E.g.:
```bash
# Enforces an IPv4 environment only:
docker run --name apprise 
   -p 8000:8000 \
   -e PUID=$(id -u) \
   -e PGID=$(id -g) \
   -e IPV4_ONLY=y \
   -e APPRISE_STATEFUL_MODE=simple \
   -e APPRISE_WORKER_COUNT=1 \
   -d caronc/apprise:latest
```

In the example, i set the `IPV4_ONLY` to `y`, but really it doesn't matter what you equate the environment variable too.  As long as it has been defined, it will trigger the enforcing code of the respeced IP version.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] Tests added
