### PR TITLE
Improved 'empty attachment handling' when feature is disabled

### DIFF
--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -258,7 +258,7 @@ def parse_attachments(attachment_payload, files_request):
     attachments = []
 
     if settings.APPRISE_ATTACH_SIZE <= 0:
-        if not (attachment_payload and files_request):
+        if not (attachment_payload or files_request):
             # No further processing required
             return []
 

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -257,6 +257,14 @@ def parse_attachments(attachment_payload, files_request):
     """
     attachments = []
 
+    if settings.APPRISE_ATTACH_SIZE <= 0:
+        if not (attachment_payload and files_request):
+            # No further processing required
+            return []
+
+        # Otherwise we need to raise an error
+        raise ValueError("Attachment support has been disabled")
+
     # Attachment Count
     count = sum([
         0 if not isinstance(attachment_payload, (set, tuple, list))
@@ -268,9 +276,6 @@ def parse_attachments(attachment_payload, files_request):
         # Convert and adjust counter
         attachment_payload = (attachment_payload, )
         count += 1
-
-    if settings.APPRISE_ATTACH_SIZE <= 0:
-        raise ValueError("Attachment support has been disabled")
 
     if settings.APPRISE_MAX_ATTACHMENTS > 0 and count > settings.APPRISE_MAX_ATTACHMENTS:
         raise ValueError(


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #168, [apprise/1200](https://github.com/caronc/apprise/discussions/1200), #169, 

Be a little less restrictive on the Attachment checking when they are disabled in the Apprise-API. This will signifigantly increase the user experience with those who choose to use [LSIO](https://www.linuxserver.io/) over my build as well since it has Apprise-API with attachments disabled by default.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] Tests added
