### PR TITLE
removed 'root' docker initialization requirement

### DIFF
--- a/apprise_api/supervisord-startup
+++ b/apprise_api/supervisord-startup
@@ -22,42 +22,51 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-if [ $(id -u) -ne 0 ]; then
-   echo "You must be root to run this script."
-   echo "Caution: This should only be ran in a dockerized instance!"
-   exit 1
+if [ $(id -u) -eq 0 ]; then
+   #
+   # Root User
+   #
+   echo "Apprise API Super User Startup"
+
+   # Default values
+   PUID=${PUID:=1000}
+   PGID=${PGID:=1000}
+
+   # lookup our identifier
+   GROUP=$(getent group $PGID 2>/dev/null | cut -d: -f1)
+   [ -z "$GROUP" ] && groupadd --force -g $PGID apprise &>/dev/null && \
+      GROUP=apprise
+
+   USER=$(id -un $PUID 2>/dev/null)
+   [ $? -ne 0 ] && useradd -M -N \
+        -o -u $PUID -G $GROUP -c "Apprise API User" -d /opt/apprise apprise && \
+        USER=apprise
+
+   if [ -z "$USER" ]; then
+      echo "The specified User ID (PUID) of $PUID is invalid; Aborting operation."
+      exit 1
+
+   elif [ -z "$GROUP" ]; then
+      echo "The specified Group ID (PGID) of $PGID is invalid; Aborting operation."
+      exit 1
+   fi
+
+  # Ensure our group has been correctly assigned
+  usermod -a -G $GROUP $USER &>/dev/null
+  chmod o+w /dev/stdout /dev/stderr
+
+else
+   #
+   # Non-Root User
+   #
+   echo "Apprise API Non-Super User Startup"
+   USER=$(id -un 2>/dev/null)
+   GROUP=$(id -gn 2>/dev/null)
 fi
-
-# Default values
-PUID=${PUID:=1000}
-PGID=${PGID:=1000}
-
-# lookup our identifier
-GROUP=$(getent group $PGID 2>/dev/null | cut -d: -f1)
-[ -z "$GROUP" ] && groupadd --force -g $PGID apprise &>/dev/null && \
-   GROUP=apprise
-
-USER=$(id -un $PUID 2>/dev/null)
-[ $? -ne 0 ] && useradd -M -N \
-     -o -u $PUID -G $GROUP -c "Apprise API User" -d /opt/apprise apprise && \
-     USER=apprise
-
-if [ -z "$USER" ]; then
-   echo "The specified User ID (PUID) of $PUID is invalid; Aborting operation."
-   exit 1
-
-elif [ -z "$GROUP" ]; then
-   echo "The specified Group ID (PGID) of $PGID is invalid; Aborting operation."
-   exit 1
-fi
-
-# Ensure our group has been correctly assigned
-usermod -a -G $GROUP $USER &>/dev/null
-chmod o+w /dev/stdout /dev/stderr
 
 [ ! -d /attach ] && mkdir -p /attach
 chown -R $USER:$GROUP /attach
-[ ! -d /config ] && mkdir -p /config /config/store
+[ ! -d /config/store ] && mkdir -p /config/store
 chown $USER:$GROUP /config
 chown -R $USER:$GROUP /config/store
 [ ! -d /plugin ] && mkdir -p /plugin
@@ -91,5 +100,6 @@ cd /opt/apprise
 
 # Launch our SupervisorD
 /usr/local/bin/supervisord -c /opt/apprise/webapp/etc/supervisord.conf
+
 # Always return our SupervisorD return code
 exit $?


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs [discussion/229](https://github.com/caronc/apprise-api/discussions/229)

Removed `root` requirement to start the Apprise API Container

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] Tests added
