### PR TITLE
Stateless Notify API now returns log data

### DIFF
--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -493,6 +493,34 @@ class StatelessNotifyTests(SimpleTestCase):
             assert mock_notify.call_count == 0
 
     @mock.patch('apprise.Apprise.notify')
+    def test_notify_html_response_block(self, mock_notify):
+        """
+        Test HTML log formatting block is triggered in StatelessNotifyView
+        """
+        mock_notify.return_value = True
+        form_data = {
+            'urls': 'json://user@localhost',
+            'body': 'Testing HTML block',
+            'type': apprise.NotifyType.INFO,
+        }
+
+        headers = {
+            'HTTP_Accept': 'text/html',
+        }
+
+        response = self.client.post(
+            '/notify',
+            data=form_data,
+            **headers,
+        )
+
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+        assert response['Content-Type'].startswith('text/html')
+        assert b'<ul class="logs">' in response.content
+        assert b'class="logs"' in response.content
+
+    @mock.patch('apprise.Apprise.notify')
     def test_notify_by_loaded_urls_with_json(self, mock_notify):
         """
         Test sending a simple notification using JSON

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1117,7 +1117,10 @@ class NotifyView(View):
         if not json_response:
             content_type = \
                 'text/html' if re.search(r'text\/(\*|html)',
-                                         request.headers.get('Accept', ''),
+                                         request.headers.get(
+                                             'Accept', request.content_type
+                                             if request.content_type
+                                             else request.headers.get('Content-Type', '')),
                                          re.IGNORECASE) \
                 else 'text/plain'
 
@@ -1527,7 +1530,10 @@ class StatelessNotifyView(View):
         if not json_response:
             content_type = \
                 'text/html' if re.search(r'text\/(\*|html)',
-                                         request.headers.get('Accept', ''),
+                                         request.headers.get(
+                                             'Accept', request.content_type
+                                             if request.content_type
+                                             else request.headers.get('Content-Type', '')),
                                          re.IGNORECASE) \
                 else 'text/plain'
         else:


### PR DESCRIPTION
This brings the Stateless /Notify API into parity with the Stateful API /Notify/{key} endpoint.

## Description:
**Related issue (if applicable):** refs #252

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [NA] Tests added
