### PR TITLE
Remove bind option from supervisor command

### DIFF
--- a/apprise_api/etc/supervisord.conf
+++ b/apprise_api/etc/supervisord.conf
@@ -15,7 +15,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:gunicorn]
-command=gunicorn -c /opt/apprise/webapp/gunicorn.conf.py -b :8080 --worker-tmp-dir /dev/shm core.wsgi
+command=gunicorn -c /opt/apprise/webapp/gunicorn.conf.py --worker-tmp-dir /dev/shm core.wsgi
 directory=/opt/apprise/webapp
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #262 

The binds are already defined in the config file, so the IPv4/IPv6 options should be respected.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `ruff`)
* [ ] Tests added
