### PR TITLE
container ipv6/ipv4 port/initialization rework

### DIFF
--- a/apprise_api/etc/nginx.conf
+++ b/apprise_api/etc/nginx.conf
@@ -4,42 +4,44 @@ pid /run/apprise/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
-   worker_connections 768;
+   worker_connections 4096;
 }
 
 http {
-   ##
+   # Upstream Configuration
+   upstream apprise_upstream {
+       server unix:/run/apprise/gunicorn.sock max_fails=0;
+       keepalive 16;
+   }
    # Basic Settings
-   ##
    sendfile on;
    tcp_nopush on;
    types_hash_max_size 2048;
    include /etc/nginx/mime.types;
    default_type application/octet-stream;
-	# Do not display Nginx Version
    server_tokens off;
 
-   ##
    # Upload Restriction
-   ##
    client_max_body_size 500M;
 
-   ##
    # Logging Settings
-   ##
    access_log /dev/stdout;
    error_log /dev/stdout info;
 
-   ##
    # Gzip Settings
-   ##
    gzip on;
+   gzip_proxied any;
 
-   ##
    # Host Configuration
-   ##
    client_body_buffer_size 256k;
    client_body_in_file_only off;
+
+   # Retry cushions
+   proxy_next_upstream error timeout http_502 http_503 http_504;
+   proxy_next_upstream_tries 2;
+
+   # Rate Limiting for /status
+   limit_req_zone $binary_remote_addr zone=status:10m rate=5r/s;
 
    server {
       listen      8000; # IPv4 Support
@@ -51,13 +53,50 @@ http {
 
       # Main Website
       location / {
-         include /etc/nginx/uwsgi_params;
-         proxy_set_header Host $http_host;
-         proxy_set_header X-Real-IP $remote_addr;
-         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-         proxy_pass http://localhost:8080;
-         # Give ample time for notifications to fire
+         proxy_pass http://apprise_upstream;
+         proxy_http_version 1.1;
+         proxy_set_header Connection "";
+
+         proxy_set_header Accept-Encoding "";
+
+         proxy_set_header Host              $host;
+         proxy_set_header X-Forwarded-Host  $host;
+         proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header X-Real-IP         $remote_addr;
+         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+         # Long operations: leave high
          proxy_read_timeout 120s;
+
+         include /etc/nginx/location-override.conf;
+      }
+
+      # exact match: /status (no slash) => redirect once
+      location = /status { return 308 /status/; }
+
+      # exact match: /status/ (with slash)
+      location = /status/ {
+         proxy_pass http://apprise_upstream;
+         proxy_http_version 1.1;
+         proxy_set_header Connection "";
+
+         proxy_set_header Accept-Encoding "";
+
+         proxy_set_header Host              $host;
+         proxy_set_header X-Forwarded-Host  $host;
+         proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header X-Real-IP         $remote_addr;
+         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+         proxy_connect_timeout 1s;
+         proxy_send_timeout 2s;
+         proxy_read_timeout 2s;
+         proxy_buffering off;
+
+         access_log off;
+         limit_req zone=status burst=10 nodelay;
+         add_header Cache-Control "no-store";
+
          include /etc/nginx/location-override.conf;
       }
 

--- a/apprise_api/etc/supervisord.conf
+++ b/apprise_api/etc/supervisord.conf
@@ -15,7 +15,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:gunicorn]
-command=gunicorn -c /opt/apprise/webapp/gunicorn.conf.py -b :8080 --worker-tmp-dir /dev/shm core.wsgi
+command=gunicorn -c /opt/apprise/webapp/gunicorn.conf.py --worker-tmp-dir /dev/shm core.wsgi
 directory=/opt/apprise/webapp
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/apprise_api/gunicorn.conf.py
+++ b/apprise_api/gunicorn.conf.py
@@ -35,11 +35,11 @@ raw_env = [
 # This is the path as prepared in the docker compose
 pythonpath = "/opt/apprise/webapp"
 
-# bind to port 8000
-bind = [
-    "0.0.0.0:8000",  # IPv4 Support
-    "[::]:8000",  # IPv6 Support
-]
+# Bind path
+bind = ["unix:/run/apprise/gunicorn.sock"]
+
+# Define our umask
+umask = 0o117
 
 # Workers are relative to the number of CPU's provided by hosting server
 workers = int(os.environ.get("APPRISE_WORKER_COUNT", multiprocessing.cpu_count() * 2 + 1))

--- a/apprise_api/supervisord-startup
+++ b/apprise_api/supervisord-startup
@@ -80,20 +80,27 @@ sed -i -e "s/^\(group[ \t]*=[ \t]*\).*$/\1$GROUP/g" \
    /opt/apprise/webapp/etc/supervisord.conf
 
 if [ "${IPV4_ONLY+x}" ] && [ "${IPV6_ONLY+x}" ]; then
-  echo -n "Warning: both IPV4_ONLY and IPV6_ONLY flags set; ambigious; no changes made."
+  echo "ERROR: Both IPV4_ONLY and IPV6_ONLY are set. Exiting."
+  exit 1
 
 # Handle IPV4_ONLY flag
 elif [ "${IPV4_ONLY+x}" ]; then
-  echo -n "Enforcing Exclusive IPv4 environment... "
-  sed -ibak -e '/IPv6 Support/d' /opt/apprise/webapp/etc/nginx.conf /opt/apprise/webapp/gunicorn.conf.py && \
+  echo -n "Network mode: IPv4-only (IPV4_ONLY set) ... "
+  sed -ibak -e '/IPv6 Support/d' /opt/apprise/webapp/etc/nginx.conf && \
      echo "Done." || echo "Failed!"
 
 # Handle IPV6_ONLY flag
 elif [ "${IPV6_ONLY+x}" ]; then
-  echo -n "Enforcing Exclusive IPv6 environment... "
-  sed -ibak -e '/IPv4 Support/d' /opt/apprise/webapp/etc/nginx.conf /opt/apprise/webapp/gunicorn.conf.py && \
+  echo -n "Network mode: IPv6-only (IPV6_ONLY set) ... "
+  sed -ibak -e '/IPv4 Support/d' /opt/apprise/webapp/etc/nginx.conf && \
      echo "Done." || echo "Failed!"
 fi
+
+# The following entry will help identify how internal network configurations
+# may be set up on the host that could cause problems.  This is used for debugging
+# only; it was originall created to support https://github.com/caronc/apprise-api/issues/262
+echo "Resolution of 'localhost' inside container:"
+getent ahosts localhost || true
 
 # Working directory
 cd /opt/apprise


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #262

### Entrypoint / startup.sh
In general, the script was improved to better handle ipv6/ipv4 environments. Additionall debugging was added as well for future situations should they arrise (to assist with debugging he problem).

- Print effective network mode at boot (dual-stack, IPv4-only, IPv6-only).
- Add localhost resolution debug lines (via getent ahosts localhost).
- Guard: error and exit if both IPV4_ONLY and IPV6_ONLY are set.
  - If IPV4_ONLY → remove IPv6 bind.
  - If IPV6_ONLY → remove IPv4 bind.
- If neither is set:
  - When bindv6only=0 → keep only IPv6 bind (covers v4+v6).
  - When bindv6only=1 → keep both binds.
  - When IPv6 disabled → keep only IPv4 bind.

### Gunicorn
Bind Gunicorn to a socket file (eliminating confusion over extra port Nginx.

### Nginx
Refactored completely
- Move upstream apprise_upstream { ... } inside http { }.
- Upstream uses server 127.0.0.1:8080; keepalive 16
- New dedicated health endpoint that serves `/status` and `/status/` identically

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `ruff`)
* [x] Tests added