### PR TITLE
fixes 'include' references to support recursive configuration imports

### DIFF
--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -517,7 +517,7 @@ function config_init() {
             // user notification
             Swal.fire({
               title: '{% trans "Save" %}',
-              html: '{% trans "Successfully saved the specified URL(s)." %}',
+              html: '{% trans "Successfully saved the configuration." %}',
               icon: 'success'
             });
          } else if(response.status == 500) {

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -545,8 +545,8 @@ class AddView(View):
                     )
                 )
 
-            # prepare our apprise config object
-            ac_obj = apprise.AppriseConfig()
+            # Prepare our apprise config object
+            ac_obj = apprise.AppriseConfig(recursion=settings.APPRISE_RECURSION_MAX)
 
             if fmt == AUTO_DETECT_CONFIG_KEYWORD:
                 # By setting format to None, it is automatically detected from
@@ -1382,7 +1382,7 @@ class NotifyView(View):
         a_obj = apprise.Apprise(asset=asset)
 
         # Create an apprise config object
-        ac_obj = apprise.AppriseConfig(asset=asset)
+        ac_obj = apprise.AppriseConfig(asset=asset, recursion=settings.APPRISE_RECURSION_MAX)
 
         # Load our configuration
         ac_obj.add_config(config, format=format)
@@ -2179,7 +2179,7 @@ class JsonUrlView(View):
         a_obj = apprise.Apprise()
 
         # Create an apprise config object
-        ac_obj = apprise.AppriseConfig()
+        ac_obj = apprise.AppriseConfig(recursion=settings.APPRISE_RECURSION_MAX)
 
         # Load our configuration
         ac_obj.add_config(config, format=format)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #272 

This was a tricky bug to track down and just ended up being a few quick changes;  the circumstance is the use of `include` calls in the configuration.  Previous to this commit they were not being retrieved (as they do for the Apprise CLI tool).

<img width="1152" height="539" alt="image" src="https://github.com/user-attachments/assets/8ba33932-efe6-44c5-9b4d-db488d3c5d11" />

The above :point_up: will now correctly resolve the following:
<img width="1141" height="455" alt="image" src="https://github.com/user-attachments/assets/29dcbe83-8f9f-48e3-be90-93636ba5a766" />

For this example, the configuration was pulled from these two simple `text` configuration files, but `yaml` will work fine too.  the `APPRISE_RECURSION_MAX` environment variable determines how many recursion levels one can go.  By default this is set to `1` (as [defined here](https://github.com/caronc/apprise-api?tab=readme-ov-file#environment-variables)).

<img width="1147" height="581" alt="image" src="https://github.com/user-attachments/assets/1db9a74f-ab80-4866-99f7-9b6c3e9723b5" />
<img width="1147" height="581" alt="image" src="https://github.com/user-attachments/assets/bf7debca-bb3e-4460-b635-7feedef68992" />


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `ruff`)
* [ ] Tests added
