### PR TITLE
Support HTTP_PORT as Docker environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,8 +480,9 @@ The use of environment variables allow you to provide over-rides to default sett
 |--------------------- | ----------- |
 | `PUID` | The User ID you wish the Apprise services under the hood to run as when the container starts as root and no explicit `--user` / `user:` has been set. The default is `1000` if not otherwise specified.
 | `PGID` | The Group ID used in the same scenario as `PUID`. If the container is started with an explicit `--user` or `user:`, that value takes precedence and `PUID` / `PGID` are not consulted for process privileges.
-| `IPV4_ONLY` | Force an all IPv4 only environment (default supports both IPV4 and IPv6).  Nothing is done if `IPV6_ONLY` is also set as this creates an ambigious setup.
-| `IPV6_ONLY` | Force an all IPv6 only environment (default supports both IPv4 and IPv6).  Nothing is done if `IPV4_ONLY` is also set as this creates an ambigious setup.
+| `IPV4_ONLY` | Force an all IPv4 only environment (default supports both IPV4 and IPv6).  Nothing is done if `IPV6_ONLY` is also set as this creates an ambigious setup.  **Note**: This only works if the container is not explicitly started with `--user` or `user:`.
+| `IPV6_ONLY` | Force an all IPv6 only environment (default supports both IPv4 and IPv6).  Nothing is done if `IPV4_ONLY` is also set as this creates an ambigious setup.  **Note**: This only works if the container is not explicitly started with `--user` or `user:`.
+| `HTTP_PORT` | Force the default listening port to be something other then `8000` within the Docker container. **Note**: This only works if the container is not explicitly started with `--user` or `user:`.
 | `APPRISE_DEFAULT_THEME` | Can be set to `light` or `dark`; it defaults to `light` if not otherwise provided.  The theme can be toggled from within the website as well.
 | `APPRISE_DEFAULT_CONFIG_ID` | Defaults to `apprise`.   This is the presumed configuration ID you always default to when accessing the configuration manager via the website.
 | `APPRISE_CONFIG_DIR` | Defines an (optional) persistent store location of all configuration files saved. By default:<br/> - Configuration is written to the `apprise_api/var/config` directory when just using the _Django_ `manage runserver` script. However for the path for the container is `/config`.

--- a/apprise_api/supervisord-startup
+++ b/apprise_api/supervisord-startup
@@ -86,6 +86,16 @@ chmod 1777 /tmp/apprise 2>/dev/null || true
 chown -R "$USER:$GROUP" /attach /config /config/store \
    /plugin /opt/apprise /tmp/apprise 2>/dev/null || true
 
+if [ ! -z "${HTTP_PORT}" ]; then
+  echo -n "Nginx/HTTP over-ride TCP/IP Listen Port: ${HTTP_PORT} ... "
+  if [ -w /opt/apprise/webapp/etc/nginx.conf ]; then
+    sed -i -e "s/^\([ \t]*listen[ \t]\+[^0-9]*\)\([^;]\+\);\(.*\)/\1${HTTP_PORT};\3/g" \
+       /opt/apprise/webapp/etc/nginx.conf &>/dev/null && echo "Done." || echo "Failed!"
+  else
+    echo "Skipped (nginx.conf not writable)."
+  fi
+fi
+
 if [ "${IPV4_ONLY+x}" ] && [ "${IPV6_ONLY+x}" ]; then
   echo "ERROR: Both IPV4_ONLY and IPV6_ONLY are set. Exiting."
   exit 1
@@ -117,6 +127,12 @@ fi
 echo "Resolution of 'localhost' inside container:"
 getent ahosts localhost || true
 
+# Get our Port Information
+PORT=$(grep -m1 -E '^[ \t]*listen[ \t]+' /opt/apprise/webapp/etc/nginx.conf 2>/dev/null | \
+   sed -e 's/^[^0-9]\+\([0-9]\+\).*/\1/g')
+PORT=${PORT:=Unknown}
+
+echo "Listening on TCP/IP Port: ${PORT}"
 # Working directory
 cd /opt/apprise
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #210

Support the `HTTP_PORT` Environment variable to change the default from port 8000. 

For example:
```bash
mkdir -p config
# The following starts the container on the internal port 80
docker run --name apprise-dev \
   -p 8000:80 \
   -e PUID=$(id -u) \
   -e PGID=$(id -g) \
   -e HTTP_PORT=80 \
   -e APPRISE_STATEFUL_MODE=simple \
   -e APPRISE_WORKER_COUNT=1 \
   -v ./config:/config \
   -d caronc/apprise:edge
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `ruff`)
* [ ] Tests added
