### PR TITLE
fix: fixes reverse proxy port issues

### DIFF
--- a/apprise_api/etc/nginx-strict.conf
+++ b/apprise_api/etc/nginx-strict.conf
@@ -81,8 +81,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -111,8 +111,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -144,8 +144,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -178,8 +178,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -214,8 +214,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -242,8 +242,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -271,8 +271,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -297,8 +297,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;

--- a/apprise_api/etc/nginx.conf
+++ b/apprise_api/etc/nginx.conf
@@ -81,8 +81,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -106,8 +106,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -134,8 +134,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -164,8 +164,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -196,8 +196,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -220,8 +220,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -245,8 +245,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -271,8 +271,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -325,8 +325,8 @@ http {
             proxy_set_header Accept-Encoding "";
             proxy_set_header Transfer-Encoding "";
 
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             # See https://github.com/caronc/apprise-api/issues/275
             # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #291 

This should fix #291. The reasons for the port errors are, that nginx strips the port when using `$host`, but `$http_host` keeps the port and therefore works. This can be easily verified on localhost. I provide an minimum reproducible example as reference.

<details>
  <summary>compose.yml</summary>
  
```yml
services:
  apprise:
    image: caronc/apprise:latest
    container_name: apprise
    ports:
      - "8000:8000"
    environment:
      APPRISE_WORKER_COUNT: "1"
    volumes:
      - ./nginx.conf:/opt/apprise/webapp/etc/nginx.conf
    labels:
      - "traefik.http.routers.apprise.rule=Host(`apprise.localhost`)"

  traefik:
    image: traefik:3
    container_name: traefik
    command:
      - --providers.docker=true
      - --entrypoints.web.address=:8080
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    restart: always
    ports:
      - 8080:8080
```
  
</details>

<details>
  <summary>nginx.conf</summary>

```text
daemon off;
worker_processes auto;
pid /tmp/apprise/nginx.pid;
include /etc/nginx/modules-enabled/*.conf;

events {
    worker_connections 4096;
}

http {
    # Upstream Configuration
    upstream apprise_upstream {
        server unix:/tmp/apprise/gunicorn.sock max_fails=0;
        keepalive 16;
    }

    # Basic Settings
    sendfile on;
    tcp_nopush on;
    types_hash_max_size 2048;
    include /etc/nginx/mime.types;
    default_type application/octet-stream;
    server_tokens off;

    # Upload Restriction
    client_max_body_size 500M;

    # Logging Settings
    access_log /dev/stdout;
    error_log /dev/stdout info;

    # Centralize configuration so docker containers can easily make use
    # of tmpfs mounted to /tmp
    client_body_temp_path /tmp/nginx_client_temp 1 2;
    proxy_temp_path /tmp/nginx_proxy_temp 1 2;
    fastcgi_temp_path /tmp/nginx_fastcgi_temp 1 2;
    uwsgi_temp_path /tmp/nginx_uwsgi_temp 1 2;
    scgi_temp_path /tmp/nginx_scgi_temp 1 2;

    # Gzip Settings
    gzip on;
    gzip_proxied any;
    gzip_vary on;
    gzip_min_length 1024;
    gzip_types application/json text/plain text/css application/javascript text/xml application/xml;

    # Host Configuration
    client_body_buffer_size 256k;
    client_body_in_file_only off;

    # Retry cushions
    proxy_next_upstream error timeout http_502 http_503 http_504;
    proxy_next_upstream_tries 2;

    # Rate Limiting for /status
    limit_req_zone $binary_remote_addr zone=status:10m rate=5r/s;

    server {
        listen 8000; # IPv4 Support
        listen [::]:8000; # IPv6 Support

        # Allow users to map to this file and provide their own custom
        # overrides such as
        include /etc/nginx/server-override.conf;

        # Error handling
        proxy_intercept_errors on;
        error_page 404 = /_/404/;
        error_page 500 = /_/50x/;
        error_page 502 503 504 /50x.html;

        #
        # 1. Root welcome page: GET /
        #    Django: WelcomeView at "^$"
        #
        location = / {
            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

            proxy_read_timeout 120s;

            include /etc/nginx/location-override.conf;
        }

        #
        # 2. Stateless notify: POST /notify
        #    Django: StatelessNotifyView at "^notify/?$"
        #
        location = /notify {
            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_request_buffering off;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header Expect $http_expect;

            client_max_body_size 500M;
            proxy_read_timeout 300s;
            proxy_send_timeout 300s;

            include /etc/nginx/location-override.conf;
        }

        #
        # 3. Stateful notify with key: POST /notify/<key>
        #    Django: NotifyView at "^notify/(?P<key>[\w_-]{1,128})/?$"
        #
        location ~ "^/notify/[\w_-]{1,128}/?$" {
            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_request_buffering off;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header Expect $http_expect;

            client_max_body_size 500M;
            proxy_read_timeout 300s;
            proxy_send_timeout 300s;

            include /etc/nginx/location-override.conf;
        }

        #
        # 4. Health check: GET /status or /status/
        #    Django: HealthCheckView at "^status/?$"
        #
        location ~ ^/status/?$ {
            # normalise internally to /status/ (no client redirect)
            rewrite ^/status/?$ /status/ break;

            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

            proxy_connect_timeout 1s;
            proxy_send_timeout 2s;
            proxy_read_timeout 2s;
            proxy_buffering off;

            access_log off;
            limit_req zone=status burst=10 nodelay;
            add_header Cache-Control "no-store" always;

            include /etc/nginx/location-override.conf;
        }

        #
        # 5. Service discovery and metadata
        #    Django: DetailsView "^details/?$"
        #            JsonUrlView "^json/urls/(?P<key>[\w_-]{1,128})/?$"
        #
        location ~ "^/(details|json/urls/[\w_-]{1,128})/?$" {
            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

            proxy_read_timeout 120s;

            include /etc/nginx/location-override.conf;
        }

        #
        # 6. Config list view: GET /cfg
        #    Django: ConfigListView "^cfg/?$"
        #
        location = /cfg {
            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

            proxy_read_timeout 120s;
            include /etc/nginx/location-override.conf;
        }

        #
        # 7. Django Error Handling: GET /_/
        #    404 /_/404/
        #    50x /_/40x/
        location /_/ {
            proxy_intercept_errors off;

            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

            proxy_read_timeout 120s;
        }

        #
        # 8. Config management (HTML UI + API)
        #    Django:
        #      ConfigView "^cfg/(?P<key>[\w_-]{1,128})/?$"  [GET, POST]
        #      AddView   "^add/(?P<key>[\w_-]{1,128})/?$"  [POST]
        #      DelView   "^del/(?P<key>[\w_-]{1,128})/?$"  [POST]
        #      GetView   "^get/(?P<key>[\w_-]{1,128})/?$"  [POST]
        #
        location ~ "^/(cfg|add|del|get)/[\w_-]{1,128}/?$" {
            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

            proxy_read_timeout 300s;

            include /etc/nginx/location-override.conf;
        }

        #
        # 9. Static content: /s/
        #
        location /s/ {
            # root points to /usr/share/nginx/html
            # so /s/... maps to /usr/share/nginx/html/s/...
            root /usr/share/nginx/html;
            index index.html;
            include /etc/nginx/location-override.conf;
        }

        #
        # 10. Serve favicon.ico
        #
        location = /favicon.ico {
            root /usr/share/nginx/html/s;
            access_log off;
            log_not_found off;
        }

        #
        # 11. Serve robots.txt
        #
        location = /robots.txt {
            access_log off;
            log_not_found off;
            default_type text/plain;
            return 200 "User-agent: *\nDisallow: /\n";
        }

        #
        # 12. Catch-all: anything not explicitly whitelisted above
        #     is handled here.
        #
        location / {
            proxy_pass http://apprise_upstream;
            proxy_http_version 1.1;
            proxy_set_header Connection "";

            proxy_set_header Accept-Encoding "";
            proxy_set_header Transfer-Encoding "";

            proxy_set_header Host $http_host;
            proxy_set_header X-Forwarded-Host $http_host;
            # See https://github.com/caronc/apprise-api/issues/275
            # Avoid - proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

            include /etc/nginx/location-override.conf;
        }
    }
}

```

</details>

Running this **without** the adjusted `nginx.conf` (i.e. commenting out the mount in my example) I get

`http://apprise.localhost/cfg/apprise` with traefik
<img width="1004" height="750" alt="image" src="https://github.com/user-attachments/assets/8c3ee3fc-8bc5-43ea-a07c-bdfac7efe048" />

`http://localhost/cfg/apprise` direct call
<img width="801" height="743" alt="image" src="https://github.com/user-attachments/assets/d8e6db34-0f07-4bd3-b434-c94f5a979d81" />


Running this **with** the adjusted `nginx.conf` I get

`http://apprise.localhost:8080/cfg/apprise` with traefik
<img width="940" height="752" alt="image" src="https://github.com/user-attachments/assets/9fd6b5c3-6887-4bbf-adbd-872370b87a4f" />

`http://localhost:8000/cfg/apprise` direct call
<img width="878" height="762" alt="image" src="https://github.com/user-attachments/assets/cacd5350-e08b-4900-8592-cf0df9ac4a1a" />

I tested this locally and also were able to successfully sent notification, so I suspect there should be no negative impact. However, if you have a better proposed solution, I'm of cause open for adjustments.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `ruff`)
* [ ] Tests added
