### PR TITLE
Case sensitive field mapping in place

### DIFF
--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -52,24 +52,22 @@ def remap_fields(rules, payload, form=None):
 
     # First generate our expected keys; only these can be mapped
     expected_keys = set(form.fields.keys())
-    for _key, value in rules.items():
-        key = _key.lower()
+    for key, value in rules.items():
         if key in payload and not value:
             # Remove element
             del payload[key]
             continue
 
-        vkey = value.lower()
-        if vkey in expected_keys and key in payload:
-            if key not in expected_keys or vkey not in payload:
+        if value in expected_keys and key in payload:
+            if key not in expected_keys or value not in payload:
                 # replace
-                payload[vkey] = payload[key]
+                payload[value] = payload[key]
                 del payload[key]
 
-            elif vkey in payload:
+            elif value in payload:
                 # swap
-                _tmp = payload[vkey]
-                payload[vkey] = payload[key]
+                _tmp = payload[value]
+                payload[value] = payload[key]
                 payload[key] = _tmp
 
         elif key in expected_keys or key in payload:

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -1448,3 +1448,57 @@ class NotifyTests(SimpleTestCase):
         response = self.client.post("/notify/{}".format(key), data=form_data, **headers)
         assert response.status_code == 400
         assert mock_notify.call_count == 0
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_by_loaded_urls_rule_mapping_preserves_source_case(
+        self, mock_notify
+    ):
+        """
+        Test that rule-based field remapping preserves source key case
+        with stateless notifications.
+        """
+
+        mock_notify.return_value = True
+
+        key = "test_notify_rule_mapping_preserves_source_case"
+
+        response = self.client.post(
+            "/add/{}".format(key),
+            {"urls": "mailto://user:pass@yahoo.ca"},
+        )
+        assert response.status_code == 200
+
+        #
+        # JSON payload using mixed-case source keys
+        #
+        json_data = {
+            "Title": "Test Notification",
+            "Description": "Test Notification Description",
+        }
+
+        response = self.client.post(
+            "/notify/{}?:Title=title&:Description=body".format(key),
+            data=json.dumps(json_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+
+        mock_notify.reset_mock()
+
+        #
+        # Case-sensitive verification:
+        # lower-case payload should not match mixed-case rule names
+        #
+        json_data = {
+            "title": "Test Notification",
+            "description": "Test Notification Description",
+        }
+
+        response = self.client.post(
+            "/notify/{}?:Title=title&:Description=body".format(key),
+            data=json.dumps(json_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0

--- a/apprise_api/api/tests/test_stateful_notify.py
+++ b/apprise_api/api/tests/test_stateful_notify.py
@@ -431,6 +431,7 @@ class StatefulNotifyTests(SimpleTestCase):
     def test_stateful_group_dictlist_notify(self, mock_post):
         """
         Test the handling of a group defined as a list of dictionaries
+        while remaining case sensitive
         """
 
         # our key to use
@@ -521,3 +522,87 @@ class StatefulNotifyTests(SimpleTestCase):
 
         # Reset our count
         mock_post.reset_mock()
+
+    @patch("requests.post")
+    def test_stateful_notify_rule_mapping_preserves_source_case(self, mock_post):
+        """
+        Test that rule-based field remapping preserves source key case
+        for both FORM and JSON payloads.
+        """
+
+        key = "test_stateful_notify_rule_mapping_preserves_source_case"
+
+        request = Mock()
+        request.content = b"ok"
+        request.status_code = requests.codes.ok
+        mock_post.return_value = request
+
+        # Ensure required plugins are enabled
+        N_MGR["pbul"].enabled = True
+        N_MGR["json"].enabled = True
+
+        urls = [
+            "pushbullet=pbul://tokendetails",
+            "private,json=json://hostname",
+        ]
+
+        response = self.client.post(
+            "/add/{}".format(key),
+            {"config": "\r\n".join(urls)},
+        )
+        assert response.status_code == 200
+
+        #
+        # FORM payload using mixed-case source keys
+        #
+        form_data = {
+            "Title": "Test Notification",
+            "Description": "Test Notification Description",
+            "tags": "private",
+        }
+
+        response = self.client.post(
+            f"/notify/{key}/?:Title=title&:Description=body&:tags=tag",
+            form_data,
+        )
+        assert response.status_code == 200
+        assert mock_post.call_count == 1
+
+        mock_post.reset_mock()
+
+        #
+        # JSON payload using mixed-case source keys
+        #
+        json_data = {
+            "Title": "Test Notification",
+            "Description": "Test Notification Description",
+            "tags": "private",
+        }
+
+        response = self.client.post(
+            f"/notify/{key}/?:Title=title&:Description=body&:tags=tag",
+            dumps(json_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert mock_post.call_count == 1
+
+        mock_post.reset_mock()
+
+        #
+        # Case-sensitive verification:
+        # lower-case payload should not match mixed-case rule names
+        #
+        json_data = {
+            "title": "Test Notification",
+            "description": "Test Notification Description",
+            "tags": "private",
+        }
+
+        response = self.client.post(
+            f"/notify/{key}/?:Title=title&:Description=body&:tags=tag",
+            dumps(json_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert mock_post.call_count == 0


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #296

Apprise API to be case sensitive when mapping field names

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `ruff`)
* [x] Tests added
