### PR TITLE
Suppress nginx/http logging noise surrounding status/metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV PYTHONUNBUFFERED=1
 ENV APPRISE_CONFIG_DIR=/config
 ENV APPRISE_ATTACH_DIR=/attach
 ENV APPRISE_PLUGIN_PATHS=/plugin
+ENV TZ=Etc/UTC
 
 FROM base AS runtime
 
@@ -21,8 +22,9 @@ COPY ./requirements.txt /etc/requirements.txt
 RUN set -eux && \
     echo "Installing nginx" && \
         apt-get update -qq && \
-        apt-get install -y -qq \
-            nginx && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            nginx \
+            tzdata && \
     echo "Installing tools" && \
         apt-get install -y -qq \
             curl sed git && \

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ docker run --name apprise \
    -e APPRISE_STATEFUL_MODE=simple \
    -e APPRISE_WORKER_COUNT=1 \
    -e APPRISE_ADMIN=y \
+   -e TZ=America/Toronto \
    -d caronc/apprise:latest
 ```
 
@@ -93,6 +94,7 @@ docker run --name apprise \
    -e APPRISE_STATEFUL_MODE=simple \
    -e APPRISE_WORKER_COUNT=1 \
    -e APPRISE_ADMIN=y \
+   -e TZ=America/Toronto \
    -v /etc/apprise:/config \
    -d apprise/local:latest
 
@@ -105,6 +107,7 @@ docker run --name apprise \
    -e APPRISE_STATEFUL_MODE=simple \
    -e APPRISE_WORKER_COUNT=1 \
    -e APPRISE_ADMIN=y \
+   -e TZ=America/Toronto \
    -v ./config:/config \
    -d apprise/local:latest
 ```
@@ -124,6 +127,7 @@ services:
       APPRISE_STATEFUL_MODE: simple
       APPRISE_WORKER_COUNT: "1"
       APPRISE_ADMIN: "y"
+      TZ: America/Toronto
     volumes:
       - ./config:/config
       - ./plugin:/plugin
@@ -166,6 +170,7 @@ services:
       APPRISE_STATEFUL_MODE: simple
       APPRISE_WORKER_COUNT: "1"
       APPRISE_ADMIN: "y"
+      TZ: America/Toronto
 
     # Persistent state
     volumes:
@@ -525,6 +530,7 @@ The use of environment variables allow you to provide overrides to default setti
 | `APPRISE_BASE_URL`    | Those who are hosting the API behind a proxy that requires a subpath to gain access to this API should specify this path here as well.  By default this is not set at all.
 | `LOG_LEVEL`    | Adjust the log level to the console. Possible values are `CRITICAL`, `ERROR`, `WARNING`, `INFO`, and `DEBUG`.
 | `DEBUG`            | This defaults to `no` and can however be set to `yes` by simply defining the global variable as such.
+| `TZ` | Sets the timezone for all log timestamps produced by both Nginx and the application. Both services run inside the same container and share this setting. Defaults to `Etc/UTC` if not specified. Any IANA timezone name is accepted (e.g. `America/New_York`, `Europe/London`) as `tzdata` is included in the container image. See the [list of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for valid values.
 
 
 ## Nginx Overrides
@@ -569,6 +575,7 @@ docker run --name apprise \
    -e APPRISE_STATEFUL_MODE=simple \
    -e APPRISE_WORKER_COUNT=1 \
    -e APPRISE_ADMIN=y \
+   -e TZ=America/Toronto \
    -d caronc/apprise:latest
 ```
 
@@ -672,6 +679,8 @@ spec:
               value: "1000"
             - name: PUID
               value: "1000"
+            - name: TZ
+              value: America/Toronto
           image: caronc/apprise:1.1
           name: apprise
           ports:
@@ -762,6 +771,8 @@ spec:
               value: "1"
             - name: APPRISE_ADMIN
               value: "y"
+            - name: TZ
+              value: America/Toronto
           ports:
             - containerPort: 8000
               name: http

--- a/apprise_api/etc/nginx-strict.conf
+++ b/apprise_api/etc/nginx-strict.conf
@@ -27,7 +27,11 @@ http {
 
     # Logging Settings
     access_log /dev/stdout;
-    error_log /dev/stdout info;
+    # error level suppresses two recurring benign warnings:
+    #   [info]  "client closed keepalive connection" -- routine TCP teardown noise
+    #   [warn]  "upstream sent more data than specified in Content-Length header" --
+    #           a harmless HTTP/1.1 keepalive framing quirk on Django 204 responses
+    error_log /dev/stdout error;
 
     # Centralize configuration so docker containers can easily make use
     # of tmpfs mounted to /tmp
@@ -174,6 +178,8 @@ http {
         location ~ "^/(status|metrics)/?$" {
             # normalise internally to /status/ (no client redirect)
             rewrite ^/status/?$ /status/ break;
+            # rewrite /metrics/ -> /metrics (no client redirect)
+            rewrite ^/metrics/$ /metrics break;
 
             proxy_pass http://apprise_upstream;
             proxy_http_version 1.1;

--- a/apprise_api/etc/nginx-strict.conf
+++ b/apprise_api/etc/nginx-strict.conf
@@ -52,7 +52,7 @@ http {
     proxy_next_upstream error timeout http_502 http_503 http_504;
     proxy_next_upstream_tries 2;
 
-    # Rate Limiting for /status
+    # Rate Limiting for /status and /metrics
     limit_req_zone $binary_remote_addr zone=status:10m rate=5r/s;
 
     server {
@@ -168,9 +168,10 @@ http {
 
         #
         # 4. Health check: GET /status or /status/
+        #    Metrics:     GET /metrics or /metrics/
         #    Django: HealthCheckView at "^status/?$"
         #
-        location ~ ^/status/?$ {
+        location ~ "^/(status|metrics)/?$" {
             # normalise internally to /status/ (no client redirect)
             rewrite ^/status/?$ /status/ break;
 
@@ -282,6 +283,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
             proxy_read_timeout 120s;
+            access_log off;
         }
 
         #

--- a/apprise_api/etc/nginx.conf
+++ b/apprise_api/etc/nginx.conf
@@ -52,7 +52,7 @@ http {
     proxy_next_upstream error timeout http_502 http_503 http_504;
     proxy_next_upstream_tries 2;
 
-    # Rate Limiting for /status
+    # Rate Limiting for /status and /metrics
     limit_req_zone $binary_remote_addr zone=status:10m rate=5r/s;
 
     server {
@@ -154,9 +154,10 @@ http {
 
         #
         # 4. Health check: GET /status or /status/
+        #    Metrics:     GET /metrics or /metrics/
         #    Django: HealthCheckView at "^status/?$"
         #
-        location ~ ^/status/?$ {
+        location ~ "^/(status|metrics)/?$" {
             # normalise internally to /status/ (no client redirect)
             rewrite ^/status/?$ /status/ break;
 
@@ -256,6 +257,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
             proxy_read_timeout 120s;
+            access_log off;
         }
 
         #

--- a/apprise_api/etc/nginx.conf
+++ b/apprise_api/etc/nginx.conf
@@ -27,7 +27,11 @@ http {
 
     # Logging Settings
     access_log /dev/stdout;
-    error_log /dev/stdout info;
+    # error level suppresses two recurring benign warnings:
+    #   [info]  "client closed keepalive connection" -- routine TCP teardown noise
+    #   [warn]  "upstream sent more data than specified in Content-Length header" --
+    #           a harmless HTTP/1.1 keepalive framing quirk on Django 204 responses
+    error_log /dev/stdout error;
 
     # Centralize configuration so docker containers can easily make use
     # of tmpfs mounted to /tmp
@@ -160,6 +164,8 @@ http {
         location ~ "^/(status|metrics)/?$" {
             # normalise internally to /status/ (no client redirect)
             rewrite ^/status/?$ /status/ break;
+            # rewrite /metrics/ -> /metrics (no client redirect)
+            rewrite ^/metrics/$ /metrics break;
 
             proxy_pass http://apprise_upstream;
             proxy_http_version 1.1;

--- a/apprise_api/etc/supervisord.conf
+++ b/apprise_api/etc/supervisord.conf
@@ -18,6 +18,8 @@ stderr_logfile_maxbytes=0
 [program:gunicorn]
 command=gunicorn -c /opt/apprise/webapp/gunicorn.conf.py --worker-tmp-dir /dev/shm core.wsgi
 directory=/opt/apprise/webapp
+; Gunicorn's control server creates a socket under $HOME/.gunicorn.
+environment=HOME="/tmp/apprise"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/apprise_api/gunicorn.conf.py
+++ b/apprise_api/gunicorn.conf.py
@@ -59,5 +59,8 @@ max_requests_jitter = 50
 # Logging
 # '-' means log to stdout.
 errorlog = "-"
-accesslog = "-"
+# Access logging is handled entirely by nginx, which sits in front of
+# gunicorn and already logs every request
+# Enabling gunicorn's own access log produces duplicate entries
+accesslog = None
 loglevel = "warn"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       APPRISE_STATEFUL_MODE: simple
       APPRISE_WORKER_COUNT: "1"
       APPRISE_ADMIN: "y"
+      TZ: America/Toronto
 
     volumes:
       - ./config:/config


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** refs #309

Suppress logging entries surrounding status/metrics + added TZ= support

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `ruff`)
* [ ] Tests added


Here was how i tested it:
```bash
# Clone the branch
git clone -b 309-noisy-log-suppression https://github.com/caronc/apprise-api.git
cd apprise-api

docker build -t apprise-api:dev -f Dockerfile .
docker rm -f apprise-dev
[ -d config ] && rm -rf config

mkdir -p config
docker run --name apprise-dev \
   -p 8000:8000 \
   -e PUID=$(id -u) \
   -e PGID=$(id -g) \
   -e APPRISE_STATEFUL_MODE=simple \
   -e APPRISE_WORKER_COUNT=1 \
   -e APPRISE_ADMIN=y \
   -e TZ="America/Toronto" \
   -v ./config:/config \
   -d apprise-api:dev

# Now visit localhost:8000 to see your dev instance of the docker container running to test against
```

Then to test:
**Terminal 1**
```bash
# Terminal 1 -- tail the container logs live while you run the curls below
docker logs -f apprise-dev
```

**Terminal 2**
```bash
# Terminal 2 -- run these one at a time and watch Terminal 1

# -----------------------------------------------------------------------
# These SHOULD appear in the access log (normal traffic)
# -----------------------------------------------------------------------

# Root page
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/

# A stateless notify call (body required; expect 400 if no URLs configured)
curl -s -o /dev/null -w "%{http_code}\n" \
   -X POST http://localhost:8000/notify/ \
   -d "body=test"

# -----------------------------------------------------------------------
# These should NOT appear in the access log (suppressed endpoints)
# -----------------------------------------------------------------------

# Health check -- simulate kube-probe / uptime monitoring
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/status/
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/status

# Prometheus metrics scrape -- simulate what Prometheus does every 15s
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/metrics
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/metrics/

# -----------------------------------------------------------------------
# Simulate rapid polling (what Prometheus / kube-probe actually does)
# Run this and confirm the access log stays silent for the duration
# -----------------------------------------------------------------------
for i in $(seq 1 10); do
   curl -s -o /dev/null http://localhost:8000/status/
   curl -s -o /dev/null http://localhost:8000/metrics
   sleep 1
done
```