### PR TITLE
Added requirements in preparation for Threema E2E and Keybase support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
   "PGPy",
   "smpplib",
   "slixmpp >= 1.10.0",
+  # Provides Threema Gateway E2E encryption support
+  "PyNaCl",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "PGPy",
   "smpplib",
   "slixmpp >= 1.10.0",
-  # Provides Threema Gateway E2E encryption support
+  # Provides Keybase & Threema Gateway E2E encryption support
   "PyNaCl",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,8 @@ PGPy
 smpplib
 # For xmpp:// support
 slixmpp >= 1.10.0
+# Provides Threema Gateway E2E encryption support
+PyNaCl
 
 # prometheus metrics
 django-prometheus

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ PGPy
 smpplib
 # For xmpp:// support
 slixmpp >= 1.10.0
-# Provides Threema Gateway E2E encryption support
+# Provides Keybase & Threema Gateway E2E encryption support
 PyNaCl
 
 # prometheus metrics


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #[apprise/1570](https://github.com/caronc/apprise/pull/1570)

New updates to the Threema Plugin allows for E2E Encryption Support

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/30](https://github.com/caronc/apprise-docs/pull/30)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b threema-requirements https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Alternatively, spin up the full stack with Docker
docker compose up
```
