### PR TITLE
Add support for webhook subfield mapping of nested fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ The colon `:` prefix is the switch that starts the re-mapping rule engine.  You 
 
 ### Nested / Subfield Mapping
 
-If your third-party payload contains nested objects you can reach into them using **dot-notation** on the source side of the mapping rule:
+If your third-party payload contains nested objects, use **dot-notation** on the source side to walk into them:
 
 ```bash
 # Payload sent by the third-party tool:
@@ -1036,9 +1036,27 @@ curl -X POST \
     "http://localhost:8000/notify/{KEY}?:event.title=title&:event.state=type&:component.name=body"
 ```
 
+If your payload contains **arrays**, use **bracket-notation** (`[N]`) to dereference an element by index. Dot-notation and bracket-notation can be freely combined:
+
+```bash
+# Payload from a forum / project-management webhook (e.g. Scoold / Para):
+# {
+#   "items": [ { "title": "New post", "objectURI": "https://example.com/q/1234" } ]
+# }
+curl -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"items":[{"title":"New post","objectURI":"https://example.com/q/1234"}]}' \
+    "http://localhost:8000/notify/{KEY}?:items[0].title=title&:items[0].objectURI=body"
+```
+
+Multiple consecutive subscripts traverse nested arrays — `matrix[0][1]` gives row 0, column 1.
+
 **Notes:**
-- Only the **source** side of the rule may use dot-notation; the target must be a flat Apprise field (`title`, `body`, `type`, `format`, etc.).
-- The maximum traversal depth defaults to **5** levels and is controlled by the `APPRISE_WEBHOOK_MAPPING_MAX_DEPTH` environment variable.
+- Only the **source** side of the rule may use path notation; the target must be a flat Apprise field (`title`, `body`, `type`, `format`, `tag`, etc.).
+- `N` in `[N]` must be a non-negative integer. Unmatched brackets (`key[0`, `key0]`) and non-integer indices (`key[abc]`) are both rejected with a `WARNING`.
+- If any step cannot be resolved (missing key, index out of range, or a non-list node at an index step), the request returns **400** and a `WARNING` is logged — no notification is sent.
+- **Depth** counts every individual traversal operation: each dict-key lookup _and_ each array-index dereference. `items[0].objectURI` = 3 steps; `a[0][1][2].value[3]` = 6 steps.
+- The maximum traversal depth defaults to **5** and is controlled by the `APPRISE_WEBHOOK_MAPPING_MAX_DEPTH` environment variable.
 
 ## Metrics Collection & Analysis
 

--- a/README.md
+++ b/README.md
@@ -1018,6 +1018,27 @@ The colon `:` prefix is the switch that starts the re-mapping rule engine.  You 
 1. `:existing_key=`: By setting no value, the existing key is simply removed from the payload entirely
 1. `:expected_key=A value to give it`: You can also fix an expected apprise key to a pre-generated string value.
 
+### Nested / Subfield Mapping
+
+If your third-party payload contains nested objects you can reach into them using **dot-notation** on the source side of the mapping rule:
+
+```bash
+# Payload sent by the third-party tool:
+# {
+#   "event":     { "title": "CPU spike", "state": "critical" },
+#   "component": { "name": "web-server-01" }
+# }
+#
+# Map nested fields to the flat Apprise fields:
+curl -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"event":{"title":"CPU spike","state":"critical"},"component":{"name":"web-server-01"}}' \
+    "http://localhost:8000/notify/{KEY}?:event.title=title&:event.state=type&:component.name=body"
+```
+
+**Notes:**
+- Only the **source** side of the rule may use dot-notation; the target must be a flat Apprise field (`title`, `body`, `type`, `format`, etc.).
+- The maximum traversal depth defaults to **5** levels and is controlled by the `APPRISE_WEBHOOK_MAPPING_MAX_DEPTH` environment variable.
 
 ## Metrics Collection & Analysis
 

--- a/README.md
+++ b/README.md
@@ -1048,16 +1048,6 @@ curl -X POST \
     -d '{"items":[{"title":"New post","objectURI":"https://example.com/q/1234"}]}' \
     "http://localhost:8000/notify/{KEY}?:items[0].title=title&:items[0].objectURI=body"
 ```
-
-Multiple consecutive subscripts traverse nested arrays — `matrix[0][1]` gives row 0, column 1.
-
-**Notes:**
-- Only the **source** side of the rule may use path notation; the target must be a flat Apprise field (`title`, `body`, `type`, `format`, `tag`, etc.).
-- `N` in `[N]` must be a non-negative integer. Unmatched brackets (`key[0`, `key0]`) and non-integer indices (`key[abc]`) are both rejected with a `WARNING`.
-- If any step cannot be resolved (missing key, index out of range, or a non-list node at an index step), the request returns **400** and a `WARNING` is logged — no notification is sent.
-- **Depth** counts every individual traversal operation: each dict-key lookup _and_ each array-index dereference. `items[0].objectURI` = 3 steps; `a[0][1][2].value[3]` = 6 steps.
-- The maximum traversal depth defaults to **5** and is controlled by the `APPRISE_WEBHOOK_MAPPING_MAX_DEPTH` environment variable.
-
 ## Metrics Collection & Analysis
 
 Basic Prometheus support added through `/metrics` reference point.

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -32,7 +32,7 @@ from django.conf import settings
 logger = logging.getLogger("django")
 
 # Matches a single [N] subscript at the start of a string.
-_SUBSCRIPT_RE = re.compile(r'^\[(\d+)\]')
+_SUBSCRIPT_RE = re.compile(r"^\[(\d+)\]")
 
 
 def _parse_path(key):
@@ -41,8 +41,8 @@ def _parse_path(key):
 
     Each step is a ``('key', name)`` or ``('index', N)`` tuple:
 
-    * ``('key', name)``  – perform a dict lookup for *name*.
-    * ``('index', N)``   – dereference integer index *N* of the current list.
+    * ``('key', name)``  - perform a dict lookup for *name*.
+    * ``('index', N)``   - dereference integer index *N* of the current list.
 
     Supported forms::
 
@@ -75,10 +75,7 @@ def _parse_path(key):
         # A stray ']' before any '[' is immediately malformed.
         bracket_pos = segment.find("[")
         if bracket_pos == -1:
-            return None, (
-                f"malformed bracket notation at '{segment}'"
-                f" (unexpected ']' with no matching '[')"
-            )
+            return None, (f"malformed bracket notation at '{segment}' (unexpected ']' with no matching '[')")
 
         key_name = segment[:bracket_pos]
         remaining = segment[bracket_pos:]
@@ -91,11 +88,10 @@ def _parse_path(key):
             m = _SUBSCRIPT_RE.match(remaining)
             if not m:
                 return None, (
-                    f"malformed bracket notation at '{segment}';"
-                    f" expected [N] where N is a non-negative integer"
+                    f"malformed bracket notation at '{segment}'; expected [N] where N is a non-negative integer"
                 )
             steps.append(("index", int(m.group(1))))
-            remaining = remaining[m.end():]
+            remaining = remaining[m.end() :]
 
     return steps, None
 
@@ -116,8 +112,7 @@ def _get_nested(payload, steps, source_key):
         if step_type == "key":
             if not isinstance(current, dict) or step_val not in current:
                 logger.warning(
-                    "Payload mapping path '%s' not found in payload"
-                    " (stopped at key '%s')",
+                    "Payload mapping path '%s' not found in payload (stopped at key '%s')",
                     source_key,
                     step_val,
                 )
@@ -127,8 +122,7 @@ def _get_nested(payload, steps, source_key):
         else:  # 'index'
             if not isinstance(current, (list, tuple)):
                 logger.warning(
-                    "Payload mapping path '%s': [%d] is not indexable"
-                    " (expected a list/array, got %s)",
+                    "Payload mapping path '%s': [%d] is not indexable (expected a list/array, got %s)",
                     source_key,
                     step_val,
                     type(current).__name__,
@@ -138,8 +132,7 @@ def _get_nested(payload, steps, source_key):
                 current = current[step_val]
             except IndexError:
                 logger.warning(
-                    "Payload mapping path '%s': index [%d] is out of range"
-                    " (length %d)",
+                    "Payload mapping path '%s': index [%d] is out of range (length %d)",
                     source_key,
                     step_val,
                     len(current),

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -23,6 +23,7 @@
 # THE SOFTWARE.
 # import the logging library
 import logging
+import re
 
 from api.forms import NotifyForm
 from django.conf import settings
@@ -30,25 +31,121 @@ from django.conf import settings
 # Get an instance of a logger
 logger = logging.getLogger("django")
 
+# Matches a single [N] subscript at the start of a string.
+_SUBSCRIPT_RE = re.compile(r'^\[(\d+)\]')
 
-def _get_nested(payload, path_parts, source_key):
+
+def _parse_path(key):
     """
-    Traverse nested dicts following path_parts.
+    Parse a mapping key into a flat, ordered list of traversal steps.
 
-    Returns a ``(value, found)`` tuple.  Logs a WARNING when the path cannot
-    be fully resolved so the operator can diagnose misconfigured mapping rules.
+    Each step is a ``('key', name)`` or ``('index', N)`` tuple:
+
+    * ``('key', name)``  – perform a dict lookup for *name*.
+    * ``('index', N)``   – dereference integer index *N* of the current list.
+
+    Supported forms::
+
+        "title"                 → [('key', 'title')]
+        "event.title"           → [('key', 'event'), ('key', 'title')]
+        "items[0]"              → [('key', 'items'), ('index', 0)]
+        "items[0].objectURI"    → [('key', 'items'), ('index', 0),
+                                    ('key', 'objectURI')]
+        "a[0][2][2].b[3]"       → [('key', 'a'), ('index', 0), ('index', 2),
+                                    ('index', 2), ('key', 'b'), ('index', 3)]
+
+    Returns ``(steps, None)`` on success.  Returns ``(None, reason)`` when
+    the key contains malformed bracket notation — any of:
+
+    * Missing closing bracket  e.g. ``items[0``
+    * Missing opening bracket  e.g. ``items0]``
+    * Non-integer index        e.g. ``items[abc]``
+    """
+    steps = []
+    for segment in key.split("."):
+        if not segment:
+            return None, f"empty segment in path '{key}'"
+
+        if "[" not in segment and "]" not in segment:
+            # Plain dict key — no bracket characters at all
+            steps.append(("key", segment))
+            continue
+
+        # At least one bracket character is present.
+        # A stray ']' before any '[' is immediately malformed.
+        bracket_pos = segment.find("[")
+        if bracket_pos == -1:
+            return None, (
+                f"malformed bracket notation at '{segment}'"
+                f" (unexpected ']' with no matching '[')"
+            )
+
+        key_name = segment[:bracket_pos]
+        remaining = segment[bracket_pos:]
+
+        if key_name:
+            steps.append(("key", key_name))
+
+        # Consume every [N] subscript greedily; any leftover chars are malformed.
+        while remaining:
+            m = _SUBSCRIPT_RE.match(remaining)
+            if not m:
+                return None, (
+                    f"malformed bracket notation at '{segment}';"
+                    f" expected [N] where N is a non-negative integer"
+                )
+            steps.append(("index", int(m.group(1))))
+            remaining = remaining[m.end():]
+
+    return steps, None
+
+
+def _get_nested(payload, steps, source_key):
+    """
+    Traverse *payload* using the pre-parsed *steps* produced by
+    :func:`_parse_path`.
+
+    Each step is a ``('key', name)`` or ``('index', N)`` tuple.
+
+    Returns ``(value, True)`` on success.  Logs a WARNING and returns
+    ``(None, False)`` when traversal cannot be completed (missing key,
+    not-indexable node, or out-of-range index).
     """
     current = payload
-    for i, part in enumerate(path_parts):
-        if not isinstance(current, dict) or part not in current:
-            partial = ".".join(path_parts[: i + 1])
-            logger.warning(
-                "Payload mapping path '%s' not found in payload (stopped at '%s')",
-                source_key,
-                partial,
-            )
-            return None, False
-        current = current[part]
+    for step_type, step_val in steps:
+        if step_type == "key":
+            if not isinstance(current, dict) or step_val not in current:
+                logger.warning(
+                    "Payload mapping path '%s' not found in payload"
+                    " (stopped at key '%s')",
+                    source_key,
+                    step_val,
+                )
+                return None, False
+            current = current[step_val]
+
+        else:  # 'index'
+            if not isinstance(current, (list, tuple)):
+                logger.warning(
+                    "Payload mapping path '%s': [%d] is not indexable"
+                    " (expected a list/array, got %s)",
+                    source_key,
+                    step_val,
+                    type(current).__name__,
+                )
+                return None, False
+            try:
+                current = current[step_val]
+            except IndexError:
+                logger.warning(
+                    "Payload mapping path '%s': index [%d] is out of range"
+                    " (length %d)",
+                    source_key,
+                    step_val,
+                    len(current),
+                )
+                return None, False
+
     return current, True
 
 
@@ -72,8 +169,22 @@ def remap_fields(rules, payload, form=None):
     mapped to the target Apprise field.  A WARNING is logged when the path
     cannot be found, so operators can diagnose misconfigured rules.
 
+    Array-index notation is also supported and may be combined freely with
+    dot-notation.  Multiple consecutive subscripts are allowed::
+
+        items[0].objectURI          # list → dict
+        data[0][2][2].value[3]      # list of lists, then dict → list
+
+    Each ``key[N]`` segment performs a dict lookup for *key* then dereferences
+    index *N* of the resulting list.  Invalid notation (missing bracket,
+    non-integer index, out-of-range index, or a non-list node) is handled
+    gracefully: a WARNING is logged and ``False`` is returned.
+
     The maximum traversal depth is controlled by the
     ``APPRISE_WEBHOOK_MAPPING_MAX_DEPTH`` Django setting (default: 5).
+    Depth is counted as the total number of individual traversal steps —
+    each dict key lookup *and* each array index dereference counts as one
+    step — so ``a[0][1].b[2]`` has a depth of 5.
 
     """
 
@@ -86,12 +197,22 @@ def remap_fields(rules, payload, form=None):
     expected_keys = set(form.fields.keys())
     for key, value in rules.items():
         # ------------------------------------------------------------------
-        # Dot-notation (subfield) path handling
+        # Dot-notation and/or array-index path handling.
+        # Any bracket character (either '[' or ']') triggers this branch so
+        # that stray/unmatched brackets are caught and rejected as malformed
+        # rather than silently falling through to flat-field handling.
         # ------------------------------------------------------------------
-        if "." in key:
-            path_parts = key.split(".")
+        if "." in key or "[" in key or "]" in key:
+            steps, err = _parse_path(key)
+            if steps is None:
+                logger.warning(
+                    "Payload mapping path '%s': %s",
+                    key,
+                    err,
+                )
+                return False
 
-            if len(path_parts) > max_depth:
+            if len(steps) > max_depth:
                 logger.warning(
                     "Payload mapping path '%s' exceeds the maximum depth of %d; skipping",
                     key,
@@ -99,7 +220,7 @@ def remap_fields(rules, payload, form=None):
                 )
                 return False
 
-            nested_value, found = _get_nested(payload, path_parts, key)
+            nested_value, found = _get_nested(payload, steps, key)
             if not found:
                 # Warning already emitted by _get_nested
                 return False
@@ -108,7 +229,7 @@ def remap_fields(rules, payload, form=None):
                 # Map the nested value to the flat Apprise field
                 payload[value] = nested_value
             # Any other combination (empty value, non-expected target) is a
-            # no-op for dot-notation sources — skip silently.
+            # no-op for dot/index sources — skip silently.
             continue
 
         # ------------------------------------------------------------------

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -24,9 +24,8 @@
 # import the logging library
 import logging
 
-from django.conf import settings
-
 from api.forms import NotifyForm
+from django.conf import settings
 
 # Get an instance of a logger
 logger = logging.getLogger("django")
@@ -86,7 +85,6 @@ def remap_fields(rules, payload, form=None):
     # First generate our expected keys; only these can be mapped
     expected_keys = set(form.fields.keys())
     for key, value in rules.items():
-
         # ------------------------------------------------------------------
         # Dot-notation (subfield) path handling
         # ------------------------------------------------------------------

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -24,10 +24,33 @@
 # import the logging library
 import logging
 
+from django.conf import settings
+
 from api.forms import NotifyForm
 
 # Get an instance of a logger
 logger = logging.getLogger("django")
+
+
+def _get_nested(payload, path_parts, source_key):
+    """
+    Traverse nested dicts following path_parts.
+
+    Returns a ``(value, found)`` tuple.  Logs a WARNING when the path cannot
+    be fully resolved so the operator can diagnose misconfigured mapping rules.
+    """
+    current = payload
+    for i, part in enumerate(path_parts):
+        if not isinstance(current, dict) or part not in current:
+            partial = ".".join(path_parts[: i + 1])
+            logger.warning(
+                "Payload mapping path '%s' not found in payload (stopped at '%s')",
+                source_key,
+                partial,
+            )
+            return None, False
+        current = current[part]
+    return current, True
 
 
 def remap_fields(rules, payload, form=None):
@@ -45,14 +68,54 @@ def remap_fields(rules, payload, form=None):
     can allow 3rd party programs that post 'subject' and 'content' to
     be remapped to say 'title' and 'body' respectively
 
+    Dot-notation keys (e.g. ``event.title``) are interpreted as paths into
+    nested dictionaries within the payload.  The resolved value is then
+    mapped to the target Apprise field.  A WARNING is logged when the path
+    cannot be found, so operators can diagnose misconfigured rules.
+
+    The maximum traversal depth is controlled by the
+    ``APPRISE_WEBHOOK_MAPPING_MAX_DEPTH`` Django setting (default: 5).
+
     """
 
     # Prepare our Form (identifies our expected keys)
     form = NotifyForm() if form is None else form
 
+    max_depth = getattr(settings, "APPRISE_WEBHOOK_MAPPING_MAX_DEPTH", 5)
+
     # First generate our expected keys; only these can be mapped
     expected_keys = set(form.fields.keys())
     for key, value in rules.items():
+
+        # ------------------------------------------------------------------
+        # Dot-notation (subfield) path handling
+        # ------------------------------------------------------------------
+        if "." in key:
+            path_parts = key.split(".")
+
+            if len(path_parts) > max_depth:
+                logger.warning(
+                    "Payload mapping path '%s' exceeds the maximum depth of %d; skipping",
+                    key,
+                    max_depth,
+                )
+                return False
+
+            nested_value, found = _get_nested(payload, path_parts, key)
+            if not found:
+                # Warning already emitted by _get_nested
+                return False
+
+            if value in expected_keys:
+                # Map the nested value to the flat Apprise field
+                payload[value] = nested_value
+            # Any other combination (empty value, non-expected target) is a
+            # no-op for dot-notation sources — skip silently.
+            continue
+
+        # ------------------------------------------------------------------
+        # Flat field handling (original behaviour)
+        # ------------------------------------------------------------------
         if key in payload and not value:
             # Remove element
             del payload[key]

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -59,6 +59,7 @@ def _parse_path(key):
 
     * Missing closing bracket  e.g. ``items[0``
     * Missing opening bracket  e.g. ``items0]``
+    * Stray ``]`` before ``[`` e.g. ``a]b[0]``
     * Non-integer index        e.g. ``items[abc]``
     """
     steps = []
@@ -79,6 +80,10 @@ def _parse_path(key):
 
         key_name = segment[:bracket_pos]
         remaining = segment[bracket_pos:]
+
+        # A ']' appearing before the first '[' is malformed (e.g. 'a]b[0]').
+        if "]" in key_name:
+            return None, (f"malformed bracket notation at '{segment}'; unexpected ']' before '['")
 
         if key_name:
             steps.append(("key", key_name))
@@ -165,13 +170,18 @@ def remap_fields(rules, payload, form=None):
     Array-index notation is also supported and may be combined freely with
     dot-notation.  Multiple consecutive subscripts are allowed::
 
-        items[0].objectURI          # list → dict
-        data[0][2][2].value[3]      # list of lists, then dict → list
+        items[0].objectURI          # list -> dict
+        data[0][2][2].value[3]      # list of lists, then dict -> list
 
     Each ``key[N]`` segment performs a dict lookup for *key* then dereferences
     index *N* of the resulting list.  Invalid notation (missing bracket,
     non-integer index, out-of-range index, or a non-list node) is handled
     gracefully: a WARNING is logged and ``False`` is returned.
+
+    **Empty target and nested paths:** setting an empty target value (e.g.
+    ``:event.title=``) for a nested-path source is a no-op — the path is
+    resolved but nothing is removed or written.  Only flat top-level keys
+    support deletion via an empty target (``?:key=``).
 
     The maximum traversal depth is controlled by the
     ``APPRISE_WEBHOOK_MAPPING_MAX_DEPTH`` Django setting (default: 5).

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -1581,9 +1581,7 @@ class NotifyTests(SimpleTestCase):
         mock_notify.reset_mock()
 
         # Depth exceeded — JSON payload
-        with self.assertLogs("django", level="WARNING") as _, override_settings(
-            APPRISE_WEBHOOK_MAPPING_MAX_DEPTH=1
-        ):
+        with self.assertLogs("django", level="WARNING") as _, override_settings(APPRISE_WEBHOOK_MAPPING_MAX_DEPTH=1):
             response = self.client.post(
                 f"/notify/{key}/?:event.title=body",
                 data=json.dumps({"event": {"title": "hi"}}),

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -1555,13 +1555,14 @@ class NotifyTests(SimpleTestCase):
         response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
         assert response.status_code == 200
 
-        # Successful subfield mapping — form POST
+        # Subfield mapping via form POST — expected to fail (400).
+        # Form POST delivers flat string values; the "event" key arrives as a
+        # plain string, not a nested dict, so the dot-notation path cannot be
+        # resolved.
         response = self.client.post(
             f"/notify/{key}/?:event.title=title&:event.body=body",
             {"event": '{"title": "hi", "body": "world"}'},
         )
-        # The form POST path delivers flat keys only; the nested JSON dict value
-        # won't resolve — expect 400, not 200
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -1538,3 +1538,67 @@ class NotifyTests(SimpleTestCase):
         with override_settings(LOGGING=bad_logging):
             response = self.client.post("/notify/{}".format(key), {"body": "test"})
         assert response.status_code == 200
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_subfield_mapping(self, mock_notify):
+        """
+        Test dot-notation subfield mapping rules at the HTTP layer (stateful).
+
+        A missing subfield path must:
+          - emit a WARNING
+          - return 400 (not attempt to send the notification)
+        """
+        mock_notify.return_value = True
+
+        key = "test_notify_subfield_mapping"
+
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        # Successful subfield mapping — form POST
+        response = self.client.post(
+            f"/notify/{key}/?:event.title=title&:event.body=body",
+            {"event": '{"title": "hi", "body": "world"}'},
+        )
+        # The form POST path delivers flat keys only; the nested JSON dict value
+        # won't resolve — expect 400, not 200
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        mock_notify.reset_mock()
+
+        # Successful subfield mapping — JSON payload
+        with self.assertLogs("django", level="WARNING") as _:
+            # event.missing does not exist → mapping fails → 400
+            response = self.client.post(
+                f"/notify/{key}/?:event.missing=body",
+                data=json.dumps({"event": {"title": "hi"}}),
+                content_type="application/json",
+            )
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        mock_notify.reset_mock()
+
+        # Depth exceeded — JSON payload
+        with self.assertLogs("django", level="WARNING") as _, override_settings(
+            APPRISE_WEBHOOK_MAPPING_MAX_DEPTH=1
+        ):
+            response = self.client.post(
+                f"/notify/{key}/?:event.title=body",
+                data=json.dumps({"event": {"title": "hi"}}),
+                content_type="application/json",
+            )
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        mock_notify.reset_mock()
+
+        # Valid nested mapping succeeds — JSON payload
+        response = self.client.post(
+            f"/notify/{key}/?:event.title=body",
+            data=json.dumps({"event": {"title": "hello world"}}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 from django.test import SimpleTestCase, override_settings
 
-from ..payload_mapper import remap_fields, _get_nested
+from ..payload_mapper import _get_nested, remap_fields
 
 
 class NotifyPayloadMapper(SimpleTestCase):

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -428,6 +428,17 @@ class NotifyPayloadMapper(SimpleTestCase):
         assert "body" not in payload
 
         #
+        # Malformed: stray ']' before '[' within a segment (e.g. a]b[0])
+        #
+        rules = {"a]b[0]": "body"}
+        payload = {"a]b": [["x"]]}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "malformed" in "\n".join(cm.output)
+        assert "body" not in payload
+
+        #
         # Malformed: non-integer index -> returns False, warning logged
         #
         rules = {"items[abc]": "body"}
@@ -534,6 +545,11 @@ class NotifyPayloadMapper(SimpleTestCase):
 
         # Malformed: partial subscript mid-chain e.g. key[0][abc]
         steps, err = _parse_path("key[0][abc]")
+        assert steps is None
+        assert "malformed" in err
+
+        # Malformed: stray ']' before '[' within a segment e.g. a]b[0]
+        steps, err = _parse_path("a]b[0]")
         assert steps is None
         assert "malformed" in err
 

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 from django.test import SimpleTestCase, override_settings
 
-from ..payload_mapper import _get_nested, remap_fields
+from ..payload_mapper import _get_nested, _parse_path, remap_fields
 
 
 class NotifyPayloadMapper(SimpleTestCase):
@@ -301,7 +301,8 @@ class NotifyPayloadMapper(SimpleTestCase):
         assert "body" not in payload
 
         #
-        # Path exceeds APPRISE_WEBHOOK_MAPPING_MAX_DEPTH — warning logged, returns False
+        # Path exceeds APPRISE_WEBHOOK_MAPPING_MAX_DEPTH — warning logged, returns False.
+        # "a.b.c" produces 3 steps; setting max_depth=2 triggers the guard.
         #
         rules = {"a.b.c": "body"}
         payload = {"a": {"b": {"c": "too deep"}}}
@@ -334,27 +335,298 @@ class NotifyPayloadMapper(SimpleTestCase):
         assert remap_fields(rules, payload) is True
         assert "nonexistent_apprise_field" not in payload
 
-    def test_get_nested(self):
+    def test_remap_fields_array_index(self):
         """
-        Test the _get_nested helper directly
+        Test bracket/array-index notation in remap_fields:
+        ``items[N]``, ``items[N].subfield``, and chained ``a[N][M][P]`` paths.
         """
 
-        # Happy path
+        #
+        # Simple array index: items[0] -> body
+        #
+        rules = {"items[0]": "body"}
+        payload = {"items": ["hello world"]}
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "hello world"
+
+        #
+        # Array index + subfield: items[0].objectURI -> body
+        # (the motivating example from issue #209)
+        #
+        rules = {"items[0].objectURI": "body", "items[0].title": "title"}
+        payload = {
+            "items": [
+                {"objectURI": "https://example.com/q/1234", "title": "New post"},
+            ]
+        }
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "https://example.com/q/1234"
+        assert payload["title"] == "New post"
+
+        #
+        # Index into a later element
+        #
+        rules = {"alerts[2]": "body"}
+        payload = {"alerts": ["a", "b", "critical failure"]}
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "critical failure"
+
+        #
+        # Chained subscripts: data[0][1] -> body
+        #
+        rules = {"data[0][1]": "body"}
+        payload = {"data": [["first", "second"], ["third", "fourth"]]}
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "second"
+
+        #
+        # Full chained path: key[0][1][2].value[3] -> body
+        # Steps: ('key','key') + [0] + [1] + [2] + ('key','value') + [3] = 6 total.
+        # Default max_depth=5 should reject; max_depth=6 should pass.
+        #
+        # Data layout so that key[0][1][2] resolves to inner:
+        #   payload["key"][0][1][2] == inner
+        #
+        inner = {"value": ["v0", "v1", "v2", "target"]}
+        payload = {"key": [[[None, None], [None, None, inner]]]}
+
+        rules = {"key[0][1][2].value[3]": "body"}
+        with self.assertLogs("django", level="WARNING") as cm, override_settings(APPRISE_WEBHOOK_MAPPING_MAX_DEPTH=5):
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "exceeds the maximum depth" in "\n".join(cm.output)
+
+        # Same path succeeds when max_depth is raised to accommodate 6 steps
+        inner = {"value": ["v0", "v1", "v2", "target"]}
+        payload = {"key": [[[None, None], [None, None, inner]]]}
+
+        with override_settings(APPRISE_WEBHOOK_MAPPING_MAX_DEPTH=6):
+            result = remap_fields(rules, payload)
+        assert result is True
+        assert payload["body"] == "target"
+
+        #
+        # Malformed: missing closing bracket -> returns False, warning logged
+        #
+        rules = {"items[0": "body"}
+        payload = {"items": ["hello"]}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "malformed" in "\n".join(cm.output)
+        assert "body" not in payload
+
+        #
+        # Malformed: missing opening bracket (stray ']') -> returns False
+        #
+        rules = {"items0]": "body"}
+        payload = {"items0]": ["hello"]}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "malformed" in "\n".join(cm.output)
+        assert "body" not in payload
+
+        #
+        # Malformed: non-integer index -> returns False, warning logged
+        #
+        rules = {"items[abc]": "body"}
+        payload = {"items": ["hello"]}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "malformed" in "\n".join(cm.output)
+
+        #
+        # Out-of-range index -> returns False, warning logged
+        #
+        rules = {"items[99]": "body"}
+        payload = {"items": ["only one"]}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "out of range" in "\n".join(cm.output)
+
+        #
+        # Target is not a list -> returns False, warning logged
+        #
+        rules = {"items[0]": "body"}
+        payload = {"items": {"key": "value"}}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "not indexable" in "\n".join(cm.output)
+
+        #
+        # Array index with no-op target (empty value) — path resolves but
+        # nothing is written; returns True
+        #
+        rules = {"items[0]": ""}
+        payload = {"items": ["hello"], "body": "keep me"}
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "keep me"
+
+        #
+        # Array index pointing to a non-expected apprise field — no-op,
+        # returns True
+        #
+        rules = {"items[0]": "nonexistent_field"}
+        payload = {"items": ["hello"]}
+        assert remap_fields(rules, payload) is True
+        assert "nonexistent_field" not in payload
+
+    def test_parse_path(self):
+        """
+        Test the _parse_path helper directly
+        """
+
+        # Plain key
+        steps, err = _parse_path("title")
+        assert err is None
+        assert steps == [("key", "title")]
+
+        # Dot-notation
+        steps, err = _parse_path("a.b.c")
+        assert err is None
+        assert steps == [("key", "a"), ("key", "b"), ("key", "c")]
+
+        # Single subscript
+        steps, err = _parse_path("items[0]")
+        assert err is None
+        assert steps == [("key", "items"), ("index", 0)]
+
+        # Subscript + subfield
+        steps, err = _parse_path("items[0].objectURI")
+        assert err is None
+        assert steps == [("key", "items"), ("index", 0), ("key", "objectURI")]
+
+        # Chained subscripts
+        steps, err = _parse_path("a[0][2][2]")
+        assert err is None
+        assert steps == [("key", "a"), ("index", 0), ("index", 2), ("index", 2)]
+
+        # Full complex path
+        steps, err = _parse_path("key[0][2][2].value[3]")
+        assert err is None
+        assert steps == [
+            ("key", "key"),
+            ("index", 0),
+            ("index", 2),
+            ("index", 2),
+            ("key", "value"),
+            ("index", 3),
+        ]
+
+        # Malformed: missing closing bracket
+        steps, err = _parse_path("items[0")
+        assert steps is None
+        assert "malformed" in err
+
+        # Malformed: stray closing bracket (no opening bracket)
+        steps, err = _parse_path("items0]")
+        assert steps is None
+        assert "malformed" in err
+
+        # Malformed: non-integer index
+        steps, err = _parse_path("items[abc]")
+        assert steps is None
+        assert "malformed" in err
+
+        # Malformed: partial subscript mid-chain e.g. key[0][abc]
+        steps, err = _parse_path("key[0][abc]")
+        assert steps is None
+        assert "malformed" in err
+
+        # Malformed: double-dot produces an empty segment
+        steps, err = _parse_path("a..b")
+        assert steps is None
+        assert "empty segment" in err
+
+        # Subscript-only segment (no key name before '[') — valid when the
+        # previous step already resolved to a list.  e.g. "items.[0]" is
+        # equivalent to "items[0]".
+        steps, err = _parse_path("items.[0]")
+        assert err is None
+        assert steps == [("key", "items"), ("index", 0)]
+
+    def test_get_nested(self):
+        """
+        Test the _get_nested helper directly (steps tuple format)
+        """
+
+        # Happy path — nested dicts
         payload = {"a": {"b": {"c": 42}}}
-        value, found = _get_nested(payload, ["a", "b", "c"], "a.b.c")
+        steps, _ = _parse_path("a.b.c")
+        value, found = _get_nested(payload, steps, "a.b.c")
         assert found is True
         assert value == 42
 
         # Missing key at first level
+        steps, _ = _parse_path("missing")
         with self.assertLogs("django", level="WARNING") as cm:
-            value, found = _get_nested({}, ["missing"], "missing")
+            value, found = _get_nested({}, steps, "missing")
         assert found is False
         assert value is None
         assert "missing" in "\n".join(cm.output)
 
         # Intermediate value is not a dict
         payload = {"a": "not-a-dict"}
+        steps, _ = _parse_path("a.b")
         with self.assertLogs("django", level="WARNING") as cm:
-            value, found = _get_nested(payload, ["a", "b"], "a.b")
+            value, found = _get_nested(payload, steps, "a.b")
         assert found is False
         assert "a.b" in "\n".join(cm.output)
+
+        # Array index: happy path
+        payload = {"items": ["first", "second", "third"]}
+        steps, _ = _parse_path("items[1]")
+        value, found = _get_nested(payload, steps, "items[1]")
+        assert found is True
+        assert value == "second"
+
+        # Chained subscripts: data[0][1]
+        payload = {"data": [["x", "y"], ["a", "b"]]}
+        steps, _ = _parse_path("data[0][1]")
+        value, found = _get_nested(payload, steps, "data[0][1]")
+        assert found is True
+        assert value == "y"
+
+        # Array index: out of range
+        payload = {"items": ["only"]}
+        steps, _ = _parse_path("items[5]")
+        with self.assertLogs("django", level="WARNING") as cm:
+            value, found = _get_nested(payload, steps, "items[5]")
+        assert found is False
+        assert "out of range" in "\n".join(cm.output)
+
+        # Array index: target key is not a list
+        payload = {"items": {"nested": "dict"}}
+        steps, _ = _parse_path("items[0]")
+        with self.assertLogs("django", level="WARNING") as cm:
+            value, found = _get_nested(payload, steps, "items[0]")
+        assert found is False
+        assert "not indexable" in "\n".join(cm.output)
+
+        # Array index: dict key not found
+        payload = {"other": ["x"]}
+        steps, _ = _parse_path("missing[0]")
+        with self.assertLogs("django", level="WARNING") as cm:
+            value, found = _get_nested(payload, steps, "missing[0]")
+        assert found is False
+        assert "missing[0]" in "\n".join(cm.output)
+
+        # Chained subscripts: second index out of range
+        payload = {"data": [["x"]]}
+        steps, _ = _parse_path("data[0][5]")
+        with self.assertLogs("django", level="WARNING") as cm:
+            value, found = _get_nested(payload, steps, "data[0][5]")
+        assert found is False
+        assert "out of range" in "\n".join(cm.output)
+
+        # Chained subscripts: intermediate is not a list
+        payload = {"data": ["scalar"]}
+        steps, _ = _parse_path("data[0][1]")
+        with self.assertLogs("django", level="WARNING") as cm:
+            value, found = _get_nested(payload, steps, "data[0][1]")
+        assert found is False
+        assert "not indexable" in "\n".join(cm.output)

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -21,9 +21,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
-from ..payload_mapper import remap_fields
+from ..payload_mapper import remap_fields, _get_nested
 
 
 class NotifyPayloadMapper(SimpleTestCase):
@@ -220,3 +220,141 @@ class NotifyPayloadMapper(SimpleTestCase):
 
         # There are no rules applied since nothing aligned
         assert payload == payload_orig
+
+    def test_remap_fields_subfields(self):
+        """
+        Test dot-notation (subfield) payload mapping
+        """
+
+        #
+        # Basic subfield mapping: event.title -> title, event.state -> type,
+        # component.name -> body  (mirrors the issue-306 use-case)
+        #
+        rules = {
+            "event.title": "title",
+            "event.state": "type",
+            "component.name": "body",
+        }
+        payload = {
+            "event": {
+                "title": "CPU spike",
+                "state": "critical",
+            },
+            "component": {
+                "name": "web-server-01",
+            },
+        }
+
+        result = remap_fields(rules, payload)
+
+        assert result is True
+        assert payload["title"] == "CPU spike"
+        assert payload["type"] == "critical"
+        assert payload["body"] == "web-server-01"
+
+        #
+        # Deeply nested path (3 levels)
+        #
+        rules = {"a.b.c": "body"}
+        payload = {"a": {"b": {"c": "deep value"}}}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "deep value"
+
+        #
+        # Missing intermediate key — warning logged, returns False
+        #
+        rules = {"missing.field": "body"}
+        payload = {"other": "data"}
+
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+
+        assert result is False
+        assert "missing.field" in "\n".join(cm.output)
+        assert "body" not in payload
+
+        #
+        # Missing leaf key — warning logged, returns False
+        #
+        rules = {"event.missing_leaf": "title"}
+        payload = {"event": {"state": "ok"}}
+
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+
+        assert result is False
+        assert "event.missing_leaf" in "\n".join(cm.output)
+        assert "title" not in payload
+
+        #
+        # Intermediate node is not a dict (e.g. it's a string) — warning logged, returns False
+        #
+        rules = {"event.title.extra": "body"}
+        payload = {"event": {"title": "flat string"}}
+
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+
+        assert result is False
+        assert "event.title.extra" in "\n".join(cm.output)
+        assert "body" not in payload
+
+        #
+        # Path exceeds APPRISE_WEBHOOK_MAPPING_MAX_DEPTH — warning logged, returns False
+        #
+        rules = {"a.b.c": "body"}
+        payload = {"a": {"b": {"c": "too deep"}}}
+
+        with self.assertLogs("django", level="WARNING") as cm, override_settings(APPRISE_WEBHOOK_MAPPING_MAX_DEPTH=2):
+            result = remap_fields(rules, payload)
+
+        assert result is False
+        assert "exceeds the maximum depth" in "\n".join(cm.output)
+        assert "body" not in payload
+
+        #
+        # Dot-notation source with empty value (no-op — path resolved, but no
+        # valid target).  Returns True because path resolution succeeded.
+        #
+        rules = {"event.title": ""}
+        payload = {"event": {"title": "hello"}, "body": "existing"}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "existing"
+        assert "title" not in payload
+
+        #
+        # Dot-notation source pointing to a non-expected apprise field — no-op
+        # Returns True because path resolution succeeded.
+        #
+        rules = {"event.title": "nonexistent_apprise_field"}
+        payload = {"event": {"title": "hello"}}
+
+        assert remap_fields(rules, payload) is True
+        assert "nonexistent_apprise_field" not in payload
+
+    def test_get_nested(self):
+        """
+        Test the _get_nested helper directly
+        """
+
+        # Happy path
+        payload = {"a": {"b": {"c": 42}}}
+        value, found = _get_nested(payload, ["a", "b", "c"], "a.b.c")
+        assert found is True
+        assert value == 42
+
+        # Missing key at first level
+        with self.assertLogs("django", level="WARNING") as cm:
+            value, found = _get_nested({}, ["missing"], "missing")
+        assert found is False
+        assert value is None
+        assert "missing" in "\n".join(cm.output)
+
+        # Intermediate value is not a dict
+        payload = {"a": "not-a-dict"}
+        with self.assertLogs("django", level="WARNING") as cm:
+            value, found = _get_nested(payload, ["a", "b"], "a.b")
+        assert found is False
+        assert "a.b" in "\n".join(cm.output)

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -859,3 +859,45 @@ class StatelessNotifyTests(SimpleTestCase):
             )
         assert response.status_code == 200
         assert mock_notify.call_count == 1
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_stateless_notify_subfield_mapping(self, mock_notify):
+        """
+        Test dot-notation subfield mapping rules at the HTTP layer (stateless).
+
+        A missing subfield path must return 400 and not attempt to send.
+        """
+        mock_notify.return_value = True
+
+        # Missing subfield — form POST, plain-text response → 400
+        with self.assertLogs("django", level="WARNING") as _:
+            response = self.client.post(
+                "/notify/?:event.missing=body",
+                data={"event": "not-a-dict"},
+            )
+        assert response.status_code == 400
+        assert b"mapping failed" in response.content
+        assert mock_notify.call_count == 0
+
+        mock_notify.reset_mock()
+
+        # Missing subfield — JSON payload → 400
+        with self.assertLogs("django", level="WARNING") as _:
+            response = self.client.post(
+                "/notify/?:event.missing=body",
+                data=json.dumps({"urls": "mailto://user:pass@yahoo.ca", "event": {"title": "hi"}}),
+                content_type="application/json",
+            )
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        mock_notify.reset_mock()
+
+        # Valid nested mapping — JSON payload → 200
+        response = self.client.post(
+            "/notify/?:event.title=body",
+            data=json.dumps({"urls": "mailto://user:pass@yahoo.ca", "event": {"title": "hello"}}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1027,22 +1027,21 @@ class NotifyView(View):
                 content = json.loads(request.body.decode("utf-8"))
 
                 # Apply content rules
-                if rules:
-                    if not remap_fields(rules, content):
-                        status = ResponseCode.bad_request
-                        msg = _("Payload field mapping failed using KEY: {}").format(key)
-                        return (
-                            HttpResponse(msg, status=status, content_type="text/plain")
-                            if not json_response
-                            else JsonResponse(
-                                {
-                                    "error": msg,
-                                },
-                                encoder=JSONEncoder,
-                                safe=False,
-                                status=status,
-                            )
+                if rules and not remap_fields(rules, content):
+                    status = ResponseCode.bad_request
+                    msg = _("Payload field mapping failed using KEY: {}").format(key)
+                    return (
+                        HttpResponse(msg, status=status, content_type="text/plain")
+                        if not json_response
+                        else JsonResponse(
+                            {
+                                "error": msg,
+                            },
+                            encoder=JSONEncoder,
+                            safe=False,
+                            status=status,
                         )
+                    )
 
             except RequestDataTooBig:
                 # APPRISE_UPLOAD_MAX_MEMORY_SIZE exceeded its value; this is usually
@@ -1729,22 +1728,21 @@ class StatelessNotifyView(View):
                 content = json.loads(request.body.decode("utf-8"))
 
                 # Apply content rules
-                if rules:
-                    if not remap_fields(rules, content, form=NotifyByUrlForm()):
-                        status = ResponseCode.bad_request
-                        msg = _("Payload field mapping failed")
-                        return (
-                            HttpResponse(msg, status=status, content_type="text/plain")
-                            if not json_response
-                            else JsonResponse(
-                                {
-                                    "error": msg,
-                                },
-                                encoder=JSONEncoder,
-                                safe=False,
-                                status=status,
-                            )
+                if rules and not remap_fields(rules, content, form=NotifyByUrlForm()):
+                    status = ResponseCode.bad_request
+                    msg = _("Payload field mapping failed")
+                    return (
+                        HttpResponse(msg, status=status, content_type="text/plain")
+                        if not json_response
+                        else JsonResponse(
+                            {
+                                "error": msg,
+                            },
+                            encoder=JSONEncoder,
+                            safe=False,
+                            status=status,
                         )
+                    )
 
             except RequestDataTooBig:
                 # APPRISE_UPLOAD_MAX_MEMORY_SIZE exceeded its value; this is usually

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -996,7 +996,21 @@ class NotifyView(View):
             if rules:
                 # Create a copy
                 data = request.POST.copy()
-                remap_fields(rules, data)
+                if not remap_fields(rules, data):
+                    status = ResponseCode.bad_request
+                    msg = _("Payload field mapping failed using KEY: {}").format(key)
+                    return (
+                        HttpResponse(msg, status=status, content_type="text/plain")
+                        if not json_response
+                        else JsonResponse(
+                            {
+                                "error": msg,
+                            },
+                            encoder=JSONEncoder,
+                            safe=False,
+                            status=status,
+                        )
+                    )
 
             else:
                 # Just create a pointer
@@ -1014,7 +1028,21 @@ class NotifyView(View):
 
                 # Apply content rules
                 if rules:
-                    remap_fields(rules, content)
+                    if not remap_fields(rules, content):
+                        status = ResponseCode.bad_request
+                        msg = _("Payload field mapping failed using KEY: {}").format(key)
+                        return (
+                            HttpResponse(msg, status=status, content_type="text/plain")
+                            if not json_response
+                            else JsonResponse(
+                                {
+                                    "error": msg,
+                                },
+                                encoder=JSONEncoder,
+                                safe=False,
+                                status=status,
+                            )
+                        )
 
             except RequestDataTooBig:
                 # APPRISE_UPLOAD_MAX_MEMORY_SIZE exceeded its value; this is usually
@@ -1670,7 +1698,21 @@ class StatelessNotifyView(View):
             if rules:
                 # Create a copy
                 data = request.POST.copy()
-                remap_fields(rules, data, form=NotifyByUrlForm())
+                if not remap_fields(rules, data, form=NotifyByUrlForm()):
+                    status = ResponseCode.bad_request
+                    msg = _("Payload field mapping failed")
+                    return (
+                        HttpResponse(msg, status=status, content_type="text/plain")
+                        if not json_response
+                        else JsonResponse(
+                            {
+                                "error": msg,
+                            },
+                            encoder=JSONEncoder,
+                            safe=False,
+                            status=status,
+                        )
+                    )
 
             else:
                 # Just create a pointer
@@ -1688,7 +1730,21 @@ class StatelessNotifyView(View):
 
                 # Apply content rules
                 if rules:
-                    remap_fields(rules, content, form=NotifyByUrlForm())
+                    if not remap_fields(rules, content, form=NotifyByUrlForm()):
+                        status = ResponseCode.bad_request
+                        msg = _("Payload field mapping failed")
+                        return (
+                            HttpResponse(msg, status=status, content_type="text/plain")
+                            if not json_response
+                            else JsonResponse(
+                                {
+                                    "error": msg,
+                                },
+                                encoder=JSONEncoder,
+                                safe=False,
+                                status=status,
+                            )
+                        )
 
             except RequestDataTooBig:
                 # APPRISE_UPLOAD_MAX_MEMORY_SIZE exceeded its value; this is usually

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -326,6 +326,12 @@ APPRISE_PLUGIN_PATHS = os.environ.get("APPRISE_PLUGIN_PATHS", os.path.join(BASE_
 # Setting this to zero disables the limit
 APPRISE_MAX_ATTACHMENTS = int(os.environ.get("APPRISE_MAX_ATTACHMENTS", 6))
 
+# The maximum depth allowed when traversing nested (dot-notation) subfields in
+# third-party webhook payload mapping rules.  For example, `:event.title=title`
+# has a depth of 2.  Raising this value too high could permit deeply recursive
+# traversal; keep it low to avoid abuse.
+APPRISE_WEBHOOK_MAPPING_MAX_DEPTH = abs(int(os.environ.get("APPRISE_WEBHOOK_MAPPING_MAX_DEPTH", 5)))
+
 # Apprise API Only mode:
 # - Disable entire Web Page and only allow the API interface to work
 # - Website requests returns 421 (Misdirected Request) for what would otherwise


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #306 and #209

Adds dot-notation subfield mapping support to the third-party webhook payload remapping rule engine.  Previously only flat top-level keys could be referenced as the source in a `:source=target` mapping rule.  This change allows nested dictionary fields to be addressed with dot-separated paths, e.g. `:event.title=title`, making it straightforward to integrate tools like Suse Observability, Grafana, or any other monitoring system that sends deeply-nested JSON payloads.

### Example

```bash
# Payload from a third-party monitoring tool:
# { "event": { "title": "CPU spike", "state": "critical" },
#   "component": { "name": "web-server-01" } }

curl -g -X POST \
  -H "Content-Type: application/json" \
  -d '{"event":{"title":"CPU spike","state":"critical"},"component":{"name":"web-server-01"}}' \
  "http://localhost:8000/notify/{KEY}?:event.title=title&:event.state=type&:component.name=body"
```

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/31](https://github.com/caronc/apprise-docs/pull/31)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b 306-map-subfields-support https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
