### PR TITLE
CRLF -> LF normalization in Configuration Tab - Alignment Fix

### DIFF
--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -608,8 +608,9 @@
     // The Paint Logic
     const update = () => {
       let text = textarea.value;
-      // Normalize CRLF/CR to LF
-      text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+      // Normalize all line-ending variants to LF so the highlight overlay stays
+      // in sync with the textarea cursor.
+      text = text.replace(/[\r\v\f]+(\n)?/g, '\n')
                  .replace(new RegExp('<', 'g'), '&lt;').replace(new RegExp('>', 'g'), '&gt;');
       if (text[text.length - 1] === "\n") {
         text += " ";

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -608,7 +608,9 @@
     // The Paint Logic
     const update = () => {
       let text = textarea.value;
-      text = text.replace(new RegExp('<', 'g'), '&lt;').replace(new RegExp('>', 'g'), '&gt;');
+      // Normalize CRLF/CR to LF
+      text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+                 .replace(new RegExp('<', 'g'), '&lt;').replace(new RegExp('>', 'g'), '&gt;');
       if (text[text.length - 1] === "\n") {
         text += " ";
       }


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #320

- Normalize the `\r\n` to `\n` in all editor configurations to potentially resolve alignment issue on Windows PCs

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [ ] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b <this.branch-name> https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
