### PR TITLE
322 timezone log fix

### DIFF
--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -36,7 +36,7 @@ APP_AUTHOR = "Chris Caron"
 APP_COPYRIGHT = "Copyright (C) 2026 Chris Caron <lead2gold@gmail.com>"
 APP_LICENSE = "MIT"
 APP_URL = "https://github.com/caronc/apprise-api"
-APP_VERSION = "1.4.0"
+APP_VERSION = "1.4.1"
 
 # Disable Timezones
 USE_TZ = False

--- a/apprise_api/gunicorn.conf.py
+++ b/apprise_api/gunicorn.conf.py
@@ -23,13 +23,23 @@
 # THE SOFTWARE.
 import multiprocessing
 import os
+import time
 
 # This file is launched with the call:
 # gunicorn --config <this file> core.wsgi:application
 
+# Apply the TZ environment variable before workers are forked so that Python's
+# time functions (used by logging formatters) use the same timezone as every
+# other process in the container (nginx, supervisord, etc.).
+if hasattr(time, "tzset"):
+    time.tzset()
+
 raw_env = [
     "LANG={}".format(os.environ.get("LANG", "en_US.UTF-8")),
     "DJANGO_SETTINGS_MODULE=core.settings",
+    # Carry the resolved TZ into every worker so Python's logging formatter
+    # uses the same timezone as nginx (which reads /etc/localtime directly).
+    "TZ={}".format(os.environ.get("TZ", "Etc/UTC")),
 ]
 
 # This is the path as prepared in the docker compose
@@ -66,3 +76,10 @@ errorlog = "-"
 # Enabling gunicorn's own access log produces duplicate entries
 accesslog = None
 loglevel = "warn"
+
+
+def post_fork(_server, _worker):
+    # Re-apply TZ in each worker after fork so Python's time functions
+    # (used by the logging formatter) use the same timezone as nginx.
+    if hasattr(time, "tzset"):
+        time.tzset()

--- a/apprise_api/supervisord-startup
+++ b/apprise_api/supervisord-startup
@@ -22,6 +22,38 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# Timezone setup: ensure all processes (nginx, gunicorn, Python logging) use
+# the same timezone so log timestamps are always aligned.
+#
+# When TZ is set it is the authority: /etc/localtime is updated to match so
+# that C programs such as nginx, which read the file directly, agree with
+# Python (which reads TZ via time.tzset() in gunicorn.conf.py).
+#
+# When TZ is not set it is derived from the environment in priority order:
+#   1. /etc/localtime symlink target  (common Docker host-timezone pattern)
+#   2. /etc/timezone                  (plain-file bind-mount fallback)
+# The derived name is exported as TZ so Python and nginx both pick it up.
+if [ -n "${TZ}" ]; then
+   if [ -f "/usr/share/zoneinfo/${TZ}" ]; then
+      echo "${TZ}" > /etc/timezone 2>/dev/null || true
+      echo "Timezone: ${TZ}"
+   else
+      echo "WARNING: TZ='${TZ}' is not a valid timezone name; timestamps may be inaccurate"
+   fi
+elif [ -L /etc/localtime ]; then
+   _tz=$(readlink /etc/localtime | sed 's|.*/zoneinfo/||')
+   if [ -n "${_tz}" ] && [ -f "/usr/share/zoneinfo/${_tz}" ]; then
+      export TZ="${_tz}"
+      echo "Timezone derived from /etc/localtime symlink: ${TZ}"
+   fi
+elif [ -f /etc/timezone ]; then
+   _tz=$(cat /etc/timezone 2>/dev/null | tr -d '[:space:]')
+   if [ -n "${_tz}" ] && [ -f "/usr/share/zoneinfo/${_tz}" ]; then
+      export TZ="${_tz}"
+      echo "Timezone derived from /etc/timezone: ${TZ}"
+   fi
+fi
+
 # Nginx configuration file
 NGINX_CONF=/opt/apprise/webapp/etc/nginx.conf
 echo "$STRICT_MODE" | cut -c1 | grep -E -m1 -q -i '\(a|y|1|e|t|+)\)' 2>/dev/null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apprise-api"
-version = "1.4.0"
+version = "1.4.1"
 authors = [{ name = "Chris Caron", email = "lead2gold@gmail.com" }]
 license = "MIT"
 dependencies = [

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5,7 +5,7 @@ info:
   description: >
     A lightweight REST framework that wraps the Apprise API Notification
     Library. See https://github.com/caronc/apprise-api for details.
-  version: 1.4.0
+  version: 1.4.1
 
 servers:
   - url: http://localhost:8000


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #322

Update to correctlly align set timezone with Apprise API logging

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): [apprise-docs/50](https://github.com/caronc/apprise-docs/pull/50)
* [ ] The change is tested and works locally.
* [ ] No commented-out code in this PR.
* [ ] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [ ] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b 322-timezone-log-fix https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
