### PR TITLE
support for optional/retry/wait/priority/escalations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,17 @@ tox -e runserver -- "localhost:8080"
 tox -e runserver -- "0.0.0.0:8080"
 ```
 
+Run against a specific Apprise core branch:
+
+```bash
+tox -e runserver -- --branch=1341-retries-and-priorities
+```
+
+When `--branch` is provided, the runserver environment force-reinstalls Apprise
+from that GitHub branch with pip caching disabled, so rerunning the command
+refreshes branch changes. Running `tox -e runserver` without `--branch` restores
+the PyPI Apprise package if the environment was previously switched to a branch.
+
 Run the test suite (supports pytest positional arguments):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -826,6 +826,17 @@ tox -e runserver -- "localhost:8080"
 tox -e runserver -- "0.0.0.0:8080"
 ```
 
+To test Apprise API against a specific Apprise core branch:
+
+```bash
+tox -e runserver -- --branch=1341-retries-and-priorities
+```
+
+The `--branch` option force-reinstalls Apprise from the named GitHub branch with
+pip caching disabled. Running `tox -e runserver` without `--branch` switches the
+environment back to the PyPI Apprise package when a branch build had previously
+been installed.
+
 ### Docker Compose for Development
 Running `docker compose up` in a fresh checkout will automatically apply `docker-compose.override.yml`.
 This mounts the local source tree and static assets into the container so UI and template changes are

--- a/apprise_api/api/templates/base.html
+++ b/apprise_api/api/templates/base.html
@@ -454,9 +454,12 @@
         if (typeof hljs !== 'undefined') {
           hljs.addPlugin({
             'before:highlightElement': function(opts) {
-              opts.el.innerHTML = opts.el.innerHTML
+              const normalizedHtml = opts.el.innerHTML
                 .replace(/<\/?br\s*\/?>([ \t]*\n[ \t]*)?/gi, '\n')
                 .replace(/\n[ \t]+/g, '\n');
+              const plainText = document.createElement('div');
+              plainText.innerHTML = normalizedHtml;
+              opts.el.textContent = plainText.textContent;
             }
           });
         }

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -417,6 +417,24 @@
       : 'notifications_off';
   }
 
+  function updateCardSelectedBadges(cardEl, group, retry) {
+    const groupBadge = cardEl.querySelector('.review-group-badge');
+    if (groupBadge) {
+      groupBadge.textContent = group ? String(group) : '';
+      groupBadge.title = group
+        ? `{% trans "Escalation group" %} ${group}`
+        : '';
+    }
+
+    const retryBadge = cardEl.querySelector('.review-retry-badge');
+    if (retryBadge) {
+      retryBadge.textContent = retry > 0 ? `x${retry}` : '';
+      retryBadge.title = retry > 0
+        ? `{% trans "Maximum number of retries attempted if the service fails before giving up" %}: ${retry}`
+        : '';
+    }
+  }
+
   function getReviewPluginTitle(serviceName, url) {
     if (serviceName && serviceName.trim().length) {
       return serviceName.trim().toUpperCase();
@@ -462,10 +480,19 @@
       });
       return;
     }
+    const debugTags = tags.map(function (tag) {
+      const token = parseNotifyTagToken(tag);
+      if (!token) {
+        return tag;
+      }
+      return token.priority === null
+        ? `${token.name}:0`
+        : `${token.priority}:${token.name}:0`;
+    });
     const formData = new FormData();
     formData.append('title', '{% trans "Apprise API Test" %}');
     formData.append('body', '{% trans "Message Body" %}');
-    formData.append('tag', tags.join(','));
+    formData.append('tag', debugTags.join(','));
 
     if (anchorEl) {
       anchorEl.disabled = true;
@@ -750,7 +777,388 @@
     if (guidance) {
       guidance.style.display = p_count === 0 ? null : 'none';
     }
+    updateReviewEscalationBadges();
   }
+
+  function parseNotifyTagToken(value) {
+    const token = String(value || '').trim();
+    const match = token.match(/^(?:(\d+):)?([A-Za-z0-9][A-Za-z0-9_-]*)(?::(\d+))?$/);
+    if (!match) {
+      return null;
+    }
+    const priority = match[1] !== undefined ? parseInt(match[1], 10) : null;
+    return {
+      name: match[2].toLowerCase(),
+      priority: priority,
+      retry: match[3] !== undefined ? parseInt(match[3], 10) : null,
+      exact: priority === null ? null : `${priority}:${match[2].toLowerCase()}`
+    };
+  }
+
+  function parseNotifyTagExpression(value) {
+    const expression = String(value || '').trim();
+    if (!expression) {
+      return [];
+    }
+    const tokens = expression.split(/[\s&+]+/).filter(function (token) {
+      return token.length > 0;
+    }).map(parseNotifyTagToken);
+    if (tokens.length === 0 || tokens.some(function (token) { return !token; })) {
+      return [];
+    }
+    return tokens;
+  }
+
+  function chipMatchesNotifyToken(chipEl, token) {
+    if (!chipEl || !token) {
+      return false;
+    }
+    if (token.name === 'all') {
+      return chipEl.dataset.tagName === 'all';
+    }
+    if (token.priority === null) {
+      return chipEl.dataset.tagName === token.name;
+    }
+    return chipEl.dataset.tagScope === 'exact' && chipEl.dataset.tagExact === token.exact;
+  }
+
+  function chipReflectsNotifyToken(chipEl, token) {
+    if (!chipEl || !token) {
+      return false;
+    }
+    if (token.name === 'all') {
+      return chipEl.dataset.tagName === 'all';
+    }
+    if (token.priority === null) {
+      return chipEl.dataset.tagScope !== 'exact' && chipEl.dataset.tagName === token.name;
+    }
+    return chipEl.dataset.tagScope === 'exact' && chipEl.dataset.tagExact === token.exact;
+  }
+
+  function selectedNotifyExpressions() {
+    const chipElement = document.querySelector('.chips');
+    const chipInstance = chipElement ? M.Chips.getInstance(chipElement) : null;
+    if (!chipInstance) {
+      return [];
+    }
+    return chipInstance.chipsData.map(function (chip) {
+      return parseNotifyTagExpression(chip.tag);
+    }).filter(function (tokens) {
+      return tokens.length > 0;
+    });
+  }
+
+  function cardMatchesNotifyTokens(card, tokens) {
+    const chips = Array.from(card.querySelectorAll('.chip[data-tag-name]'));
+    return tokens.every(function (token) {
+      return chips.some(function (chip) {
+        return chipMatchesNotifyToken(chip, token);
+      });
+    });
+  }
+
+  function cardMatchingChips(card, token) {
+    return Array.from(card.querySelectorAll('.chip[data-tag-name]')).filter(function (chip) {
+      return chipMatchesNotifyToken(chip, token);
+    });
+  }
+
+  function cardEscalationChips(card, token) {
+    return Array.from(card.querySelectorAll('.chip[data-tag-name]')).filter(function (chip) {
+      if (!token || token.name === 'all') {
+        return false;
+      }
+      if (token.priority !== null) {
+        return chipMatchesNotifyToken(chip, token);
+      }
+      return chip.dataset.tagScope === 'exact' && chip.dataset.tagName === token.name;
+    });
+  }
+
+  function buildEscalationGroups(expressions) {
+    const groups = {};
+    const cards = Array.from(
+      document.querySelectorAll('#url-list li.card-panel:not(.url-item-disabled)')
+    );
+    expressions.forEach(function (tokens) {
+      tokens.forEach(function (token) {
+        if (!token || token.name === 'all' || token.priority !== null) {
+          return;
+        }
+        groups[token.name] = groups[token.name] || new Set();
+        cards.forEach(function (card) {
+          if (!cardMatchesNotifyTokens(card, tokens)) {
+            return;
+          }
+          cardEscalationChips(card, token).forEach(function (chip) {
+            groups[token.name].add(parseInt(chip.dataset.tagPriority || '0', 10));
+          });
+        });
+      });
+    });
+
+    Object.keys(groups).forEach(function (name) {
+      const priorityMap = {};
+      const priorities = Array.from(groups[name]).sort(function (a, b) {
+        return a - b;
+      });
+      if (priorities.length <= 1) {
+        groups[name] = priorityMap;
+        return;
+      }
+      priorities.forEach(function (priority, index) {
+        priorityMap[priority] = index + 1;
+      });
+      groups[name] = priorityMap;
+    });
+    return groups;
+  }
+
+  function cardEscalationState(card, expressions, groups) {
+    let group = null;
+    const serviceRetry = parseInt(card.dataset.retryCount || '0', 10) || 0;
+    let retry = serviceRetry;
+    expressions.some(function (tokens) {
+      if (!cardMatchesNotifyTokens(card, tokens)) {
+        return false;
+      }
+      retry = serviceRetry;
+      tokens.some(function (token) {
+        if (token.retry !== null) {
+          retry = token.retry;
+          return true;
+        }
+        return false;
+      });
+      tokens.forEach(function (token) {
+        if (!token || token.name === 'all') {
+          return;
+        }
+        if (token.priority !== null) {
+          return;
+        }
+        cardEscalationChips(card, token).forEach(function (chip) {
+          const priority = parseInt(chip.dataset.tagPriority || '0', 10);
+          const tokenGroup = groups[token.name] && groups[token.name][priority];
+          if (tokenGroup) {
+            group = group === null ? tokenGroup : Math.min(group, tokenGroup);
+          }
+        });
+      });
+      return true;
+    });
+    return { group: group, retry: retry };
+  }
+
+  function updateReviewEscalationBadges() {
+    const expressions = selectedNotifyExpressions();
+    const groups = buildEscalationGroups(expressions);
+    document.querySelectorAll('#url-list li.card-panel').forEach(function (card) {
+      if (!card.classList.contains('selected') || card.classList.contains('url-item-disabled')) {
+        updateCardSelectedBadges(card, null, parseInt(card.dataset.retryCount || '0', 10) || 0);
+        return;
+      }
+      const state = cardEscalationState(card, expressions, groups);
+      updateCardSelectedBadges(card, state.group, state.retry);
+    });
+  }
+
+  function reviewTagChipsForNotifyTag(tag) {
+    const tokens = parseNotifyTagExpression(tag);
+    if (tokens.length === 0) {
+      return [];
+    }
+    const cards = Array.from(
+      document.querySelectorAll('#url-list li.card-panel:not(.url-item-disabled)')
+    );
+    return cards.reduce(function (matches, card) {
+      if (!cardMatchesNotifyTokens(card, tokens)) {
+        return matches;
+      }
+      const chips = Array.from(card.querySelectorAll('.chip[data-tag-name]'));
+      return matches.concat(chips.filter(function (chip) {
+        return tokens.some(function (token) {
+          return chipReflectsNotifyToken(chip, token);
+        });
+      }));
+    }, []);
+  }
+
+  function reviewChipMatchesNotifyTag(chip, tag) {
+    const tokens = parseNotifyTagExpression(tag);
+    if (tokens.length === 0) {
+      return false;
+    }
+    return tokens.every(function (token) {
+      return chipReflectsNotifyToken(chip, token);
+    });
+  }
+
+  function decorateNotifyChips() {
+    const chipElement = document.querySelector('#notify .chips');
+    const chipInstance = chipElement ? M.Chips.getInstance(chipElement) : null;
+    if (!chipElement || !chipInstance) {
+      return;
+    }
+    Array.from(chipElement.querySelectorAll('.chip')).forEach(function (chip, index) {
+      const tag = chipInstance.chipsData[index] && chipInstance.chipsData[index].tag
+        ? chipInstance.chipsData[index].tag
+        : chip.textContent.replace(/\s*close\s*$/i, '').trim();
+      const token = parseNotifyTagToken(tag);
+      chip.classList.add('notify-tag-chip');
+      chip.classList.toggle('notify-tag-chip-all', token && token.name === 'all');
+      chip.classList.toggle('notify-tag-chip-exact', token && token.priority !== null);
+      chip.dataset.notifyTagToken = tag;
+    });
+  }
+
+  function notifyChipTag(chipInstance, chipElement) {
+    if (chipElement.dataset.notifyTagToken) {
+      return chipElement.dataset.notifyTagToken;
+    }
+    if (chipElement.parentNode) {
+      const chips = Array.from(chipElement.parentNode.querySelectorAll('.chip'));
+      const index = chips.indexOf(chipElement);
+      if (index >= 0 && chipInstance.chipsData[index] && chipInstance.chipsData[index].tag) {
+        return chipInstance.chipsData[index].tag;
+      }
+    }
+    return chipElement.textContent.replace(/\s*close\s*$/i, '').trim();
+  }
+
+  function buildNotifyTagOptions(data) {
+    const optionMap = {
+      all: { token: 'all', name: 'all', exact: false, priority: null, hasChildren: false }
+    };
+    const priorityMap = {};
+
+    (Array.isArray(data.tags) ? data.tags : []).forEach(function (tag) {
+      const name = String(tag).toLowerCase();
+      optionMap[name] = {
+        token: name,
+        name: name,
+        exact: false,
+        priority: null,
+        hasChildren: false
+      };
+      priorityMap[name] = priorityMap[name] || {};
+    });
+
+    (Array.isArray(data.urls) ? data.urls : []).forEach(function (entry) {
+      (Array.isArray(entry.tag_details) ? entry.tag_details : []).forEach(function (detail) {
+        if (!detail || !detail.name) {
+          return;
+        }
+        const name = String(detail.name).toLowerCase();
+        const priority = parseInt(detail.priority || 0, 10) || 0;
+        const token = `${priority}:${name}`;
+        priorityMap[name] = priorityMap[name] || {};
+        priorityMap[name][priority] = token;
+        optionMap[name] = optionMap[name] || {
+          token: name,
+          name: name,
+          exact: false,
+          priority: null,
+          hasChildren: false
+        };
+      });
+    });
+
+    Object.keys(priorityMap).forEach(function (name) {
+      const priorities = Object.keys(priorityMap[name]).map(function (priority) {
+        return parseInt(priority, 10);
+      }).sort(function (a, b) {
+        return a - b;
+      });
+      if (priorities.length <= 1) {
+        return;
+      }
+      optionMap[name].hasChildren = true;
+      priorities.forEach(function (priority) {
+        const token = priorityMap[name][priority];
+        optionMap[token] = {
+          token: token,
+          name: name,
+          exact: true,
+          priority: priority,
+          hasChildren: false
+        };
+      });
+    });
+
+    const options = Object.keys(optionMap).sort(function (a, b) {
+      const itemA = optionMap[a];
+      const itemB = optionMap[b];
+      if (itemA.name !== itemB.name) {
+        if (itemA.name === 'all') {
+          return -1;
+        }
+        if (itemB.name === 'all') {
+          return 1;
+        }
+        return itemA.name.localeCompare(itemB.name);
+      }
+      if (itemA.exact !== itemB.exact) {
+        return itemA.exact ? 1 : -1;
+      }
+      return (itemA.priority || 0) - (itemB.priority || 0);
+    }).map(function (key) {
+      return optionMap[key];
+    });
+    return options;
+  }
+
+  function decorateNotifyAutocompleteOptions(optionMap) {
+    window.requestAnimationFrame(function () {
+      document.querySelectorAll('#notify .autocomplete-content').forEach(function (menu) {
+        menu.classList.add('notify-tag-autocomplete');
+      });
+      document.querySelectorAll('.autocomplete-content li').forEach(function (item) {
+        const token = item.textContent.trim();
+        const option = optionMap[token];
+        item.classList.remove(
+          'notify-tag-option-parent',
+          'notify-tag-option-exact'
+        );
+        if (!option) {
+          return;
+        }
+        item.classList.toggle('notify-tag-option-parent', option.hasChildren);
+        item.classList.toggle('notify-tag-option-exact', option.exact);
+        const label = item.querySelector('span');
+        if (label && option.exact) {
+          label.textContent = '';
+          const priority = document.createElement('span');
+          priority.setAttribute('class', 'notify-tag-option-priority-label');
+          priority.textContent = String(option.priority);
+          label.appendChild(priority);
+          const hiddenToken = document.createElement('span');
+          hiddenToken.setAttribute('class', 'notify-tag-option-token-text');
+          hiddenToken.textContent = `:${option.name}`;
+          label.appendChild(hiddenToken);
+        }
+      });
+    });
+  }
+
+  function setReviewChipSelected(chip, selected) {
+    const card = chip.closest('li.card-panel');
+    if (selected) {
+      chip.classList.add('selected');
+      if (card) {
+        card.classList.add('selected');
+        updateCardSelectedIcon(card);
+      }
+      return;
+    }
+
+    chip.classList.remove('selected');
+    if (card && !card.querySelector('.chip.selected')) {
+      card.classList.remove('selected');
+      updateCardSelectedIcon(card);
+    }
+  }
+
   function showCopyToast(anchorEl, message) {
     const msg = message || '{% trans "URL copied to clipboard" %}';
     // Try SweetAlert2 first so we can anchor to the card
@@ -852,8 +1260,13 @@
     // choose from. Tags are based off ones found in the saved
     // configuration.
     const data = await jsonResponse.json();
-    const external_data = tags.concat(data.tags).reduce(function (result, item) {
-      result[item] = null;
+    const notifyTagOptions = buildNotifyTagOptions(data);
+    const notifyTagOptionMap = notifyTagOptions.reduce(function (result, item) {
+      result[item.token] = item;
+      return result;
+    }, {});
+    const external_data = notifyTagOptions.reduce(function (result, item) {
+      result[item.token] = null;
       return result;
     }, {})
     const chipElement = document.querySelector('.chips');
@@ -862,19 +1275,17 @@
       secondaryPlaceholder: '{% trans "Add another?" %}',
       autocompleteOptions: {
         data: external_data,
-        minLength: 0
+        minLength: 0,
+        onSearch: function () {
+          decorateNotifyAutocompleteOptions(notifyTagOptionMap);
+        }
       },
       onChipAdd: function (e, data) {
         var $this = this;
-        const chip = data.childNodes[0].textContent;
-        document.querySelectorAll(`#url-list li.card-panel:not(.url-item-disabled) .chip[name=${chip}]`).forEach(function (e) {
+        const chip = notifyChipTag($this, data);
+        reviewTagChipsForNotifyTag(chip).forEach(function (e) {
           if (!e.classList.contains('selected')) {
-            e.classList.add('selected');
-            const p = e.closest('li.card-panel');
-            if (!p.classList.contains('selected')) {
-              p.classList.add('selected');
-            }
-            updateCardSelectedIcon(p);
+            setReviewChipSelected(e, true);
           }
         })
         document.querySelectorAll(`#url-list li.card-panel:not(.url-item-disabled) .chip.chip-notag`).forEach(function (e) {
@@ -890,25 +1301,20 @@
           }
         })
         $this.chipsData.forEach(function (e, index) {
-          if (!(e.tag in external_data))
+          if (!(e.tag in external_data) && parseNotifyTagExpression(e.tag).length === 0)
             $this.deleteChip(index);
         })
+        decorateNotifyChips();
         update_count();
       },
       onChipDelete: function (e, data) {
         var $this = this;
-        const chip = data.childNodes[0].textContent;
-        document.querySelectorAll(`#url-list li.card-panel:not(.url-item-disabled) .chip[name=${chip}]`).forEach(function (e) {
-          if (e.classList.contains('selected')) {
-            e.classList.remove('selected');
+        const chip = notifyChipTag($this, data);
+        reviewTagChipsForNotifyTag(chip).forEach(function (e) {
+          if (!e.classList.contains('selected')) {
+            return;
           }
-          const p = e.closest('li.card-panel');
-          if (!p.querySelector('.selected')) {
-            if (p.classList.contains('selected')) {
-              p.classList.remove('selected');
-            }
-          }
-          updateCardSelectedIcon(p);
+          setReviewChipSelected(e, false);
         })
         if ($this.chipsData.length == 0) {
           // last item
@@ -923,9 +1329,18 @@
             updateCardSelectedIcon(p);
           })
         }
+        decorateNotifyChips();
         update_count();
       }
     });
+    const chipInput = chipElement.querySelector('input');
+    if (chipInput) {
+      ['focus', 'input', 'keyup', 'click'].forEach(function (eventName) {
+        chipInput.addEventListener(eventName, function () {
+          decorateNotifyAutocompleteOptions(notifyTagOptionMap);
+        });
+      });
+    }
     {% else %}
     {# Empty external data set #}
     const data = {
@@ -940,10 +1355,13 @@
     const chipInstance = M.Chips.getInstance(chipElement);
     if (params.tag) {
       // our GET parameters to be treated as template values
-      var tagRe = new RegExp('[^[A-Za-z0-9_-]+');
+      var tagRe = new RegExp('\\s*[|,]\\s*');
       params.tag.split(tagRe).forEach(function (tag, index) {
-        chipInstance.addChip({ tag: tag, image: '' });
+        if (tag.trim().length) {
+          chipInstance.addChip({ tag: tag.trim(), image: '' });
+        }
       });
+      decorateNotifyChips();
     }
     {% if not CONFIG_LOCK %}
     // Now build our our loaded list of configuration for our welcome page
@@ -954,6 +1372,7 @@
       const entryTags = Array.isArray(entry.tags) ? entry.tags.slice() : [];
       let li = document.createElement('li');
       li.setAttribute('class', 'card-panel url-item');
+      li.dataset.retryCount = String(parseInt(entry.retry || 0, 10) || 0);
       if (!isEnabled) {
         li.classList.add('url-item-disabled');
         li.title = `{% trans "This Apprise API instance has disabled support for" %} ${getReviewPluginTitle(entry.service_name, entry.url)}.`;
@@ -967,6 +1386,20 @@
       meta.appendChild(pluginTitle);
       let metaRight = document.createElement('div');
       metaRight.setAttribute('class', 'url-meta-right');
+      let retryBadge = null;
+      if (isEnabled) {
+        retryBadge = document.createElement('span');
+        retryBadge.setAttribute('class', 'review-retry-badge');
+        metaRight.appendChild(retryBadge);
+      }
+      if (isEnabled && entry.optional === true) {
+        let optionalBadge = document.createElement('span');
+        optionalBadge.setAttribute('class', 'review-optional-badge material-icons');
+        optionalBadge.setAttribute('aria-label', '{% trans "Optional service" %}');
+        optionalBadge.title = '{% trans "Optional service: failures are ignored when determining notification success" %}';
+        optionalBadge.textContent = 'check_circle';
+        metaRight.appendChild(optionalBadge);
+      }
       // Optional URL ID
       if (entry.id) {
         let url_id = document.createElement('code');
@@ -989,6 +1422,9 @@
           ? 'notifications_active'
           : 'notifications_off';
         sel.appendChild(selIcon);
+        let groupBadge = document.createElement('span');
+        groupBadge.setAttribute('class', 'review-group-badge');
+        sel.appendChild(groupBadge);
         metaRight.appendChild(sel);
       }
       meta.appendChild(metaRight);
@@ -1025,9 +1461,57 @@
       tagList.setAttribute('class', 'url-tags');
       tagRow.appendChild(tagList);
 
-      const testTags = entryTags.filter(function (t) {
+      const entryTagDetails = Array.isArray(entry.tag_details)
+        ? entry.tag_details.slice()
+        : entryTags.map(function (tag) {
+            return {
+              name: String(tag),
+              priority: 0,
+              token: String(tag),
+              exact: `0:${String(tag)}`
+            };
+          });
+      const testTags = entryTagDetails.map(function (detail) {
+        return detail && detail.token ? detail.token : null;
+      }).filter(function (t) {
         return typeof t === 'string' && t.trim().length > 0;
       });
+      const displayTagDetails = [{
+        name: 'all',
+        priority: 0,
+        token: 'all',
+        exact: '0:all'
+      }];
+      entryTags.forEach(function (tag) {
+        displayTagDetails.push({
+          name: String(tag),
+          priority: 0,
+          token: String(tag),
+          exact: `0:${String(tag)}`,
+          scope: 'broad'
+        });
+      });
+      entryTagDetails.forEach(function (detail) {
+        if (!detail || !detail.name) {
+          return;
+        }
+        const priority = parseInt(detail.priority || 0, 10) || 0;
+        displayTagDetails.push({
+          name: String(detail.name),
+          priority: priority,
+          token: `${priority}:${String(detail.name)}`,
+          exact: `${priority}:${String(detail.name)}`,
+          scope: 'exact'
+        });
+      });
+      if (entryTagDetails.length === 0) {
+        displayTagDetails.unshift({
+          name: '',
+          priority: 0,
+          token: '',
+          exact: ''
+        });
+      }
       let testBtn = document.createElement('button');
       testBtn.type = 'button';
       testBtn.setAttribute('class', 'review-test-btn btn-flat btn-small');
@@ -1056,23 +1540,28 @@
       li.appendChild(tagRow);
 
       urlList.appendChild(li);
-      // Store `all` tag
-      entryTags.unshift('all')
-      if (entryTags.length === 1) {
-        // This entry triggers when no tags are defined
-        // Store '' (empty) tag for notice generation
-        entryTags.unshift('')
-      }
       // Get our tags associate with the URL
-      entryTags.forEach(function (tag) {
+      const renderedTags = new Set();
+      displayTagDetails.forEach(function (detail) {
+        const tag = detail && detail.token ? detail.token : String(detail.name || '');
+        const tagName = String(detail.name || tag).toLowerCase();
+        const tagExact = String(detail.exact || tag).toLowerCase();
+        if (renderedTags.has(tag)) {
+          return;
+        }
+        renderedTags.add(tag);
         let chip = document.createElement('div');
         chip.setAttribute('class', `chip`);
         if (tag.length > 0) {
           // we're dealing with a valid tag
-          chip.setAttribute('name', tag);
+          chip.dataset.tagName = tagName;
+          chip.dataset.tagToken = tag;
+          chip.dataset.tagExact = tagExact;
+          chip.dataset.tagPriority = String(parseInt(detail.priority || 0, 10) || 0);
+          chip.dataset.tagScope = detail.scope || 'exact';
           chip.textContent = `🏷️ ${tag}`;
           const index = chipInstance.chipsData.findIndex(function (e) {
-            return e.tag === tag;
+            return reviewChipMatchesNotifyTag(chip, e.tag);
           })
           if (index >= 0) {
             chip.classList.add('selected');
@@ -1085,10 +1574,10 @@
             chip.addEventListener('click', function (e) {
               e.preventDefault();
               const index = chipInstance.chipsData.findIndex(function (e) {
-                return e.tag === tag;
+                return reviewChipMatchesNotifyTag(chip, e.tag);
               });
               if (index < 0) {
-                chipInstance.addChip({ tag: this.getAttribute('name'), image: '' });
+                chipInstance.addChip({ tag: this.dataset.tagToken, image: '' });
               } else {
                 chipInstance.deleteChip(index);
               }
@@ -1415,6 +1904,7 @@
   }
 
   function notify_init() {
+    decorateNotifyChips();
     // over-ride manual submit for a nicer user experience
     document.querySelector('#donotify').onsubmit = function (event) {
       event.preventDefault();

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -1496,11 +1496,15 @@
           return;
         }
         const priority = parseInt(detail.priority || 0, 10) || 0;
+        const token = `${priority}:${String(detail.name)}`;
+        if (!notifyTagOptionMap[token] || notifyTagOptionMap[token].exact !== true) {
+          return;
+        }
         displayTagDetails.push({
           name: String(detail.name),
           priority: priority,
-          token: `${priority}:${String(detail.name)}`,
-          exact: `${priority}:${String(detail.name)}`,
+          token: token,
+          exact: token,
           scope: 'exact'
         });
       });

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -294,9 +294,21 @@
       <div class="section has-config">
         <div class="loaded-config-heading">
           <h5>{% trans "Loaded Configuration" %}</h5>
-          <p class="loaded-config-heading-status">
-            {% blocktrans %}<span class="loaded-config-heading-status-text"><span class="card-count" data-count-format="plain">0</span> notification(s) selected for sending</span>{% endblocktrans %}
-          </p>
+          <div class="loaded-config-heading-meta">
+            <label class="review-selected-filter"
+                   title="{% trans "Show only selected notification services" %}">
+              <input id="review-selected-filter-toggle"
+                     type="checkbox"
+                     aria-label="{% trans "Show only selected notification services" %}"
+                     disabled>
+              <span class="review-selected-filter-track" aria-hidden="true">
+                <span class="review-selected-filter-knob"></span>
+              </span>
+            </label>
+            <p class="loaded-config-heading-status">
+              {% blocktrans %}<span class="loaded-config-heading-status-text"><span class="card-count" data-count-format="plain">0</span> notification(s) selected for sending</span>{% endblocktrans %}
+            </p>
+          </div>
         </div>
         <div class="loaded-config-tip">
           <ul class="loaded-config-tip-list">
@@ -773,11 +785,30 @@
     document.querySelectorAll(".card-count").forEach(function (e) {
       e.textContent = e.dataset.countFormat === 'plain' ? `${p_count}` : `(${p_count})`;
     })
+    const reviewFilter = document.querySelector('#review-selected-filter-toggle');
+    if (reviewFilter) {
+      reviewFilter.disabled = p_count === 0;
+      if (p_count === 0) {
+        reviewFilter.checked = false;
+      }
+      applyReviewSelectedFilter();
+    }
     const guidance = document.querySelector('#notify-target-guidance');
     if (guidance) {
       guidance.style.display = p_count === 0 ? null : 'none';
     }
     updateReviewEscalationBadges();
+  }
+
+  function applyReviewSelectedFilter() {
+    const reviewFilter = document.querySelector('#review-selected-filter-toggle');
+    const filterActive = reviewFilter && reviewFilter.checked && !reviewFilter.disabled;
+    document.querySelectorAll('#url-list li.card-panel').forEach(function (card) {
+      card.classList.toggle(
+        'review-filter-hidden',
+        filterActive && !card.classList.contains('selected')
+      );
+    });
   }
 
   function parseNotifyTagToken(value) {
@@ -2077,6 +2108,12 @@
   document.querySelector('#id_tag').style.display = 'none';
   // Sync config tabs with URL hash and allow direct hash deep links.
   initConfigTabs();
+  const reviewSelectedFilter = document.querySelector('#review-selected-filter-toggle');
+  if (reviewSelectedFilter) {
+    reviewSelectedFilter.addEventListener('change', function () {
+      applyReviewSelectedFilter();
+    });
+  }
   /* Initialize our page */
   main_init();
   // Config ID copy-to-clipboard

--- a/apprise_api/api/templates/config.html
+++ b/apprise_api/api/templates/config.html
@@ -2161,7 +2161,6 @@
     {% if not CONFIG_LOCK %}
       /* Initialze our configuration */
       config_init();
-      hljs.highlightAll();
       initAppriseConfigEditor();
     {% endif %}
     notify_init();

--- a/apprise_api/api/tests/test_json_urls.py
+++ b/apprise_api/api/tests/test_json_urls.py
@@ -26,6 +26,26 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
+from ..views import service_optional, service_retry, tag_detail, tag_names
+
+
+class _Tag:
+    def __init__(self, name, priority=0, has_priority=False):
+        self.name = name
+        self.priority = priority
+        self.has_priority = has_priority
+
+    def __str__(self):
+        return self.name
+
+
+class _Notification:
+    def __init__(self, retry=None, optional=None):
+        if retry is not None:
+            self.retry = retry
+        if optional is not None:
+            self.optional = optional
+
 
 class JsonUrlsTests(SimpleTestCase):
     def test_get_invalid_key_status_code(self):
@@ -154,3 +174,49 @@ class JsonUrlsTests(SimpleTestCase):
         # response
         assert "Content-Type" in response
         assert response["Content-Type"].startswith("application/json")
+
+    def test_priority_tag_detail_shape(self):
+        """
+        Advanced tags should expose bare names and per-entry priority details.
+        """
+        plain = tag_detail(_Tag("family"))
+        prioritized = tag_detail(_Tag("family", priority=1, has_priority=True))
+        prioritized_string = tag_detail("2:email")
+
+        assert plain == {
+            "name": "family",
+            "priority": 0,
+            "token": "family",
+            "exact": "0:family",
+        }
+        assert prioritized == {
+            "name": "family",
+            "priority": 1,
+            "token": "1:family",
+            "exact": "1:family",
+        }
+        assert prioritized_string == {
+            "name": "email",
+            "priority": 2,
+            "token": "2:email",
+            "exact": "2:email",
+        }
+        assert tag_names(["2:email", _Tag("family")]) == {"email", "family"}
+
+    def test_service_retry_falls_back_to_url_parameter(self):
+        """
+        Retry is available from newer Apprise objects or their rendered URLs.
+        """
+        assert service_retry(_Notification(3), "mailto://user:pass@example.com?retry=2") == 3
+        assert service_retry(_Notification(), "mailto://user:pass@example.com?retry=2") == 2
+        assert service_retry(_Notification(), "mailto://user:pass@example.com") == 0
+
+    def test_service_optional_falls_back_to_url_parameter(self):
+        """
+        Optional is available from newer Apprise objects or their rendered URLs.
+        """
+        assert service_optional(_Notification(optional=True), "mailto://host?optional=no") is True
+        assert service_optional(_Notification(), "mailto://host?optional=yes") is True
+        assert service_optional(_Notification(), "mailto://host?optional=true") is True
+        assert service_optional(_Notification(), "mailto://host?optional=no") is False
+        assert service_optional(_Notification(), "mailto://host") is False

--- a/apprise_api/api/tests/test_json_urls.py
+++ b/apprise_api/api/tests/test_json_urls.py
@@ -209,6 +209,8 @@ class JsonUrlsTests(SimpleTestCase):
         """
         assert service_retry(_Notification(3), "mailto://user:pass@example.com?retry=2") == 3
         assert service_retry(_Notification(), "mailto://user:pass@example.com?retry=2") == 2
+        assert service_retry(_Notification(), "mailto://user:pass@example.com?retry=bad") == 0
+        assert service_retry(_Notification(), None) == 0
         assert service_retry(_Notification(), "mailto://user:pass@example.com") == 0
 
     def test_service_optional_falls_back_to_url_parameter(self):
@@ -219,4 +221,7 @@ class JsonUrlsTests(SimpleTestCase):
         assert service_optional(_Notification(), "mailto://host?optional=yes") is True
         assert service_optional(_Notification(), "mailto://host?optional=true") is True
         assert service_optional(_Notification(), "mailto://host?optional=no") is False
+        assert service_optional(_Notification(), None) is False
+        with patch("apprise_api.api.views.urlsplit", side_effect=TypeError):
+            assert service_optional(_Notification(), "mailto://host?optional=yes") is False
         assert service_optional(_Notification(), "mailto://host") is False

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -56,6 +56,8 @@ class NotifyTests(SimpleTestCase):
             "family:2",
             "3:friends:4",
         ]
+        with self.assertRaises(ValueError):
+            parse_tag_expression("family:")
 
     @mock.patch("apprise.Apprise.notify")
     def test_notify_accepts_advanced_tag_expression(self, mock_notify):

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -31,6 +31,7 @@ from django.test import SimpleTestCase, override_settings
 import requests
 
 from ..forms import NotifyForm
+from ..views import parse_tag_expression
 
 # Grant access to our Notification Manager Singleton
 N_MGR = apprise.manager_plugins.NotificationManager()
@@ -40,6 +41,49 @@ class NotifyTests(SimpleTestCase):
     """
     Test notifications
     """
+
+    def test_parse_advanced_tag_expression_preserves_boolean_logic(self):
+        """
+        Advanced tag tokens should not change existing OR/AND behavior.
+        """
+        assert parse_tag_expression("family friends") == [("family", "friends")]
+        assert parse_tag_expression("family+friends") == [("family", "friends")]
+        assert parse_tag_expression("family&friends") == [("family", "friends")]
+        assert parse_tag_expression("1:family 3:friends") == [("1:family", "3:friends")]
+        assert parse_tag_expression("1:family+3:friends") == [("1:family", "3:friends")]
+        assert parse_tag_expression("friends 4:family") == [("friends", "4:family")]
+        assert parse_tag_expression("family:2, 3:friends:4") == [
+            "family:2",
+            "3:friends:4",
+        ]
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_accepts_advanced_tag_expression(self, mock_notify):
+        """
+        Stateful notify should pass advanced tag expressions through to Apprise.
+        """
+        mock_notify.return_value = True
+        key = "test_notify_accepts_advanced_tag_expression"
+
+        response = self.client.post(
+            "/add/{}".format(key),
+            {"urls": "mailto://user:pass@yahoo.ca"},
+        )
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/notify/{}".format(key),
+            {
+                "body": "test notification",
+                "tag": "1:family 3:friends, friends 4:family",
+            },
+        )
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+        assert mock_notify.call_args.kwargs["tag"] == [
+            ("1:family", "3:friends"),
+            ("friends", "4:family"),
+        ]
 
     @mock.patch("apprise.Apprise.notify")
     def test_notify_by_loaded_urls(self, mock_notify):

--- a/apprise_api/api/tests/test_redos.py
+++ b/apprise_api/api/tests/test_redos.py
@@ -62,6 +62,8 @@ class ReDoSTests(SimpleTestCase):
             "tag-two",
             "tag1, tag2",
             "tag1 | tag2",
+            "tag&tag",
+            "tag+tag",
             "  tag  ",  # Leading/trailing spaces are allowed inside the match
             "\t\ttag\t\t",
             "tag\nnewline",
@@ -74,8 +76,6 @@ class ReDoSTests(SimpleTestCase):
             "tag!",
             "tag@home",
             "<script>",
-            "tag&tag",
-            "tag+tag",
         ]
 
         for tag in invalid_tags:

--- a/apprise_api/api/tests/test_runserver.py
+++ b/apprise_api/api/tests/test_runserver.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from apprise_api.runserver import install_apprise_branch, parse_args
+from apprise_api.runserver import install_apprise_branch, install_apprise_pypi, main, parse_args
 
 
 class RunserverTests(SimpleTestCase):
@@ -18,6 +18,7 @@ class RunserverTests(SimpleTestCase):
 
         command = mock_check_call.call_args.args[0]
         assert command[-1] == "git+https://github.com/caronc/apprise.git@1341-retries-and-priorities"
+        assert "--no-cache-dir" in command
         assert "--no-deps" in command
 
     def test_install_apprise_branch_rejects_shell_characters(self):
@@ -28,3 +29,34 @@ class RunserverTests(SimpleTestCase):
             install_apprise_branch("master;echo-nope")
 
         mock_check_call.assert_not_called()
+
+    def test_install_apprise_pypi(self):
+        with patch("subprocess.check_call") as mock_check_call:
+            install_apprise_pypi()
+
+        command = mock_check_call.call_args.args[0]
+        assert command[-1] == "apprise"
+        assert "--no-cache-dir" in command
+        assert "--no-deps" in command
+        assert "--force-reinstall" in command
+
+    def test_main_restores_pypi_after_branch_install(self):
+        with (
+            patch("apprise_api.runserver.apprise_is_vcs_installed", return_value=True),
+            patch("apprise_api.runserver.install_apprise_pypi") as mock_install_pypi,
+            patch("subprocess.call", return_value=0) as mock_call,
+        ):
+            assert main([]) == 0
+
+        mock_install_pypi.assert_called_once_with()
+        assert mock_call.call_args.args[0][-2:] == ["manage.py", "runserver"]
+
+    def test_main_does_not_reinstall_pypi_when_already_pypi(self):
+        with (
+            patch("apprise_api.runserver.apprise_is_vcs_installed", return_value=False),
+            patch("apprise_api.runserver.install_apprise_pypi") as mock_install_pypi,
+            patch("subprocess.call", return_value=0),
+        ):
+            assert main([]) == 0
+
+        mock_install_pypi.assert_not_called()

--- a/apprise_api/api/tests/test_runserver.py
+++ b/apprise_api/api/tests/test_runserver.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from apprise_api.runserver import install_apprise_branch, parse_args
+
+
+class RunserverTests(SimpleTestCase):
+    def test_parse_branch_option(self):
+        options, runserver_args = parse_args(["--branch=feature/retry", "127.0.0.1:8001"])
+
+        assert options.branch == "feature/retry"
+        assert runserver_args == ["127.0.0.1:8001"]
+
+    def test_install_apprise_branch(self):
+        with patch("subprocess.check_call") as mock_check_call:
+            install_apprise_branch("1341-retries-and-priorities")
+
+        command = mock_check_call.call_args.args[0]
+        assert command[-1] == "git+https://github.com/caronc/apprise.git@1341-retries-and-priorities"
+        assert "--no-deps" in command
+
+    def test_install_apprise_branch_rejects_shell_characters(self):
+        with (
+            patch("subprocess.check_call") as mock_check_call,
+            self.assertRaises(ValueError),
+        ):
+            install_apprise_branch("master;echo-nope")
+
+        mock_check_call.assert_not_called()

--- a/apprise_api/api/tests/test_runserver.py
+++ b/apprise_api/api/tests/test_runserver.py
@@ -1,8 +1,28 @@
+from importlib import metadata
+import json
+from pathlib import Path
+import runpy
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
+import warnings
 
 from django.test import SimpleTestCase
 
-from apprise_api.runserver import install_apprise_branch, install_apprise_pypi, main, parse_args
+from apprise_api.runserver import (
+    apprise_is_vcs_installed,
+    install_apprise_branch,
+    install_apprise_pypi,
+    main,
+    parse_args,
+)
+
+
+class _Distribution:
+    def __init__(self, direct_url):
+        self.direct_url = direct_url
+
+    def locate_file(self, path):
+        return self.direct_url if path == "direct_url.json" else path
 
 
 class RunserverTests(SimpleTestCase):
@@ -40,6 +60,40 @@ class RunserverTests(SimpleTestCase):
         assert "--no-deps" in command
         assert "--force-reinstall" in command
 
+    def test_apprise_is_vcs_installed(self):
+        with TemporaryDirectory() as tmpdir:
+            direct_url = Path(tmpdir) / "direct_url.json"
+            direct_url.write_text(
+                json.dumps(
+                    {
+                        "url": "https://github.com/caronc/apprise.git",
+                        "vcs_info": {"vcs": "git"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with patch("apprise_api.runserver.metadata.distribution", return_value=_Distribution(direct_url)):
+                assert apprise_is_vcs_installed() is True
+
+            direct_url.write_text(json.dumps({"url": "https://files.pythonhosted.org/apprise.whl"}), encoding="utf-8")
+            with patch("apprise_api.runserver.metadata.distribution", return_value=_Distribution(direct_url)):
+                assert apprise_is_vcs_installed() is False
+
+            direct_url.write_text("{", encoding="utf-8")
+            with patch("apprise_api.runserver.metadata.distribution", return_value=_Distribution(direct_url)):
+                assert apprise_is_vcs_installed() is False
+
+            direct_url.unlink()
+            with patch("apprise_api.runserver.metadata.distribution", return_value=_Distribution(direct_url)):
+                assert apprise_is_vcs_installed() is False
+
+    def test_apprise_is_vcs_installed_missing_distribution(self):
+        with patch(
+            "apprise_api.runserver.metadata.distribution",
+            side_effect=metadata.PackageNotFoundError,
+        ):
+            assert apprise_is_vcs_installed() is False
+
     def test_main_restores_pypi_after_branch_install(self):
         with (
             patch("apprise_api.runserver.apprise_is_vcs_installed", return_value=True),
@@ -60,3 +114,28 @@ class RunserverTests(SimpleTestCase):
             assert main([]) == 0
 
         mock_install_pypi.assert_not_called()
+
+    def test_main_installs_requested_branch(self):
+        with (
+            patch("apprise_api.runserver.install_apprise_branch") as mock_install_branch,
+            patch("apprise_api.runserver.apprise_is_vcs_installed") as mock_is_vcs,
+            patch("subprocess.call", return_value=0) as mock_call,
+        ):
+            assert main(["--branch=feature/retry", "127.0.0.1:8001"]) == 0
+
+        mock_install_branch.assert_called_once_with("feature/retry")
+        mock_is_vcs.assert_not_called()
+        assert mock_call.call_args.args[0][-1] == "127.0.0.1:8001"
+
+    def test_module_entrypoint(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            with (
+                patch("apprise_api.runserver.apprise_is_vcs_installed", return_value=False),
+                patch("subprocess.call", return_value=7),
+                patch("sys.argv", ["apprise_api.runserver"]),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                runpy.run_module("apprise_api.runserver", run_name="__main__")
+
+        assert ctx.exception.code == 7

--- a/apprise_api/api/tests/test_stateful_notify.py
+++ b/apprise_api/api/tests/test_stateful_notify.py
@@ -254,9 +254,8 @@ class StatefulNotifyTests(SimpleTestCase):
             del form.cleaned_data["attachment"]
 
             response = self.client.post("/notify/{}".format(key), form.cleaned_data)
-            # + (plus) not supported at this time
-            assert response.status_code == 400
-            assert mock_request.call_count == 0
+            assert response.status_code == 200
+            assert mock_request.call_count == 1
 
             # Reset our configuration
             mock_post.reset_mock()
@@ -277,9 +276,8 @@ class StatefulNotifyTests(SimpleTestCase):
             del form.cleaned_data["attachment"]
 
             response = self.client.post("/notify/{}".format(key), form.cleaned_data)
-            # + (plus) not supported at this time
-            assert response.status_code == 400
-            assert mock_request.call_count == 0
+            assert response.status_code == 200
+            assert mock_request.call_count == 1
 
             mock_post.reset_mock()
             mock_request.reset_mock()

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -65,6 +65,85 @@ class StatelessNotifyTests(SimpleTestCase):
         ]
 
     @mock.patch("apprise.Apprise.notify")
+    def test_notify_accepts_advanced_tag_expression_from_query_string(self, mock_notify):
+        """
+        Stateless notify should accept tag and tags query-string fallbacks.
+        """
+        mock_notify.return_value = True
+
+        payload = {
+            "urls": "mailto://user:pass@hotmail.com",
+            "body": "test notification",
+        }
+
+        response = self.client.post("/notify?tag=family:2", payload)
+        assert response.status_code == 200
+        assert mock_notify.call_args.kwargs["tag"] == ["family:2"]
+
+        mock_notify.reset_mock()
+        response = self.client.post("/notify?tags=3:friends:4", payload)
+        assert response.status_code == 200
+        assert mock_notify.call_args.kwargs["tag"] == ["3:friends:4"]
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_accepts_tag_list_without_reparsing(self, mock_notify):
+        """
+        Stateless notify should pass list-form JSON tags through as-is.
+        """
+        mock_notify.return_value = True
+
+        response = self.client.post(
+            "/notify",
+            data=json.dumps(
+                {
+                    "urls": "mailto://user:pass@hotmail.com",
+                    "body": "test notification",
+                    "tag": ["family", "3:friends:4"],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert mock_notify.call_args.kwargs["tag"] == ["family", "3:friends:4"]
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_rejects_invalid_tag_query_string(self, mock_notify):
+        """
+        Stateless notify should reject unsupported tag syntax from the query string.
+        """
+        response = self.client.post(
+            "/notify?tag=family:",
+            {
+                "urls": "mailto://user:pass@hotmail.com",
+                "body": "test notification",
+            },
+        )
+
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_rejects_non_string_tag_payload(self, mock_notify):
+        """
+        Stateless notify should reject tag payloads that are not strings or lists.
+        """
+        response = self.client.post(
+            "/notify",
+            data=json.dumps(
+                {
+                    "urls": "mailto://user:pass@hotmail.com",
+                    "body": "test notification",
+                    "tag": {"name": "family"},
+                }
+            ),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+    @mock.patch("apprise.Apprise.notify")
     def test_notify(self, mock_notify):
         """
         Test sending a simple notification

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -43,6 +43,28 @@ class StatelessNotifyTests(SimpleTestCase):
     """
 
     @mock.patch("apprise.Apprise.notify")
+    def test_notify_accepts_advanced_tag_expression(self, mock_notify):
+        """
+        Stateless notify should also respect tag filters when provided.
+        """
+        mock_notify.return_value = True
+
+        response = self.client.post(
+            "/notify",
+            {
+                "urls": "mailto://user:pass@hotmail.com",
+                "body": "test notification",
+                "tag": "family:2, 3:friends:4",
+            },
+        )
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
+        assert mock_notify.call_args.kwargs["tag"] == [
+            "family:2",
+            "3:friends:4",
+        ]
+
+    @mock.patch("apprise.Apprise.notify")
     def test_notify(self, mock_notify):
         """
         Test sending a simple notification

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -23,6 +23,7 @@
 import json
 import logging
 import re
+from urllib.parse import parse_qs, urlsplit
 
 import apprise
 from django.conf import settings
@@ -71,16 +72,120 @@ MIME_IS_FORM = re.compile(r"(multipart|application)/(x-www-)?form-(data|urlencod
 # <blank>
 ACCEPT_ALL = re.compile(r"^\s*([*]/[*]|)\s*$", re.I)
 
-# Tags separated by space , &, or + are and'ed together
+# Tags separated by space, &, or + are and'ed together
 # Tags separated by commas (even commas wrapped in spaces) are "or'ed" together
-# We start with a regular expression used to clean up provided tags
-TAG_VALIDATION_RE = re.compile(r"^[a-z0-9\s| ,_-]+$", re.IGNORECASE)
+# We start with a regular expression used to clean up provided tag expressions.
+TAG_VALIDATION_RE = re.compile(r"^[a-z0-9\s| ,_:+&-]+$", re.IGNORECASE)
 
-# In order to separate our tags only by comma's or '|' entries found
-TAG_DETECT_RE = re.compile(r"\s*([a-z0-9\s_&+-]+)(?=$|\s*[|,]\s*[a-z0-9\s&+_-|,])", re.I)
+# Split OR groups only on commas or pipes.
+TAG_OR_DELIM_RE = re.compile(r"\s*[|,]\s*")
 
-# Break apart our objects anded together
+# Break apart our objects anded together.
 TAG_AND_DELIM_RE = re.compile(r"[\s&+]+")
+
+# A single Apprise tag token. Supports [priority:]name[:retry].
+TAG_TOKEN_RE = re.compile(
+    r"^(?:[0-9]+:)?[a-z0-9][a-z0-9_-]*(?::[0-9]+)?$",
+    re.IGNORECASE,
+)
+
+
+def parse_tag_expression(tag):
+    """
+    Convert a user-provided tag expression into Apprise's OR/AND structure.
+
+    Commas and pipes are OR separators. Whitespace, ampersands, and plus signs are AND
+    separators. Individual tokens may use Apprise's advanced tag syntax:
+    [priority:]tag[:retry].
+    """
+    if not isinstance(tag, str) or not TAG_VALIDATION_RE.match(tag):
+        raise ValueError("Unsupported characters found in tag definition")
+
+    tags = []
+    for group in TAG_OR_DELIM_RE.split(tag):
+        group = group.strip()
+        if not group:
+            continue
+
+        tokens = [token for token in TAG_AND_DELIM_RE.split(group) if token]
+        if not tokens or any(not TAG_TOKEN_RE.match(token) for token in tokens):
+            raise ValueError("Unsupported characters found in tag definition")
+
+        tags.append(tuple(tokens) if len(tokens) > 1 else tokens[0])
+
+    return tags
+
+
+def tag_detail(tag):
+    """
+    Return JSON-safe tag metadata for an Apprise tag object or plain string.
+    """
+    raw_tag = str(tag)
+    match = TAG_TOKEN_RE.match(raw_tag)
+    if match and getattr(tag, "priority", None) is None:
+        parts = raw_tag.split(":")
+        if len(parts) > 1 and parts[0].isdigit():
+            priority = int(parts[0])
+            tag_name = parts[1]
+            has_priority = True
+        else:
+            priority = 0
+            tag_name = parts[0]
+            has_priority = False
+    else:
+        tag_name = raw_tag
+        priority = getattr(tag, "priority", 0)
+        has_priority = getattr(tag, "has_priority", False)
+    token = f"{priority}:{tag_name}" if has_priority or priority else tag_name
+
+    return {
+        "name": tag_name,
+        "priority": priority,
+        "token": token,
+        "exact": f"{priority}:{tag_name}",
+    }
+
+
+def tag_names(tags):
+    """
+    Return only bare tag names for UI autocomplete and legacy API consumers.
+    """
+    return {tag_detail(tag)["name"] for tag in tags}
+
+
+def service_retry(notification, url):
+    """
+    Return the configured retry count for a rendered notification URL.
+    """
+    retry = getattr(notification, "retry", 0) or 0
+    if retry:
+        return retry
+
+    try:
+        value = parse_qs(urlsplit(url).query).get("retry", [0])[0]
+        return int(value)
+
+    except (TypeError, ValueError):
+        return 0
+
+
+def service_optional(notification, url):
+    """
+    Return whether a rendered notification URL is marked optional.
+    """
+    optional = getattr(notification, "optional", None)
+    if optional is True:
+        return True
+
+    try:
+        values = parse_qs(urlsplit(url).query).get("optional")
+        if values:
+            return str(values[0]).lower() in {"1", "yes", "true", "on"}
+
+    except (TypeError, ValueError):
+        pass
+
+    return bool(optional)
 
 
 class JSONEncoder(DjangoJSONEncoder):
@@ -1188,7 +1293,10 @@ class NotifyView(View):
                 content["tag"] = tag
 
             elif isinstance(tag, str):
-                if not TAG_VALIDATION_RE.match(tag):
+                try:
+                    content["tag"] = parse_tag_expression(tag)
+
+                except ValueError:
                     # Invalid entry found in list
                     logger.warning(
                         "NOTIFY - %s - Ignored invalid tag specified (type %s): %s using KEY: %s",
@@ -1212,23 +1320,6 @@ class NotifyView(View):
                             status=status,
                         )
                     )
-
-                # If we get here, our specified tag was valid
-                tags = []
-                for _tag in TAG_DETECT_RE.findall(tag):
-                    tag = _tag.strip()
-                    if not tag:
-                        continue
-
-                    # Disect our results
-                    group = TAG_AND_DELIM_RE.split(tag)
-                    if len(group) > 1:
-                        tags.append(tuple(group))
-                    else:
-                        tags.append(tag)
-
-                # Assign our tags
-                content["tag"] = tags
 
             else:  # Could be int, float or some other unsupported type
                 logger.warning(
@@ -1819,6 +1910,72 @@ class StatelessNotifyView(View):
             content["urls"] = settings.APPRISE_STATELESS_URLS
 
         #
+        # Allow 'tag' value to be specified as part of the URL parameters
+        # if not found otherwise defined.
+        #
+        tag = content.get("tag") if content.get("tag") else content.get("tags")
+        if not tag:
+            if "tag" in request.GET:
+                tag = request.GET["tag"]
+
+            elif "tags" in request.GET:
+                tag = request.GET["tags"]
+
+        if tag:
+            if isinstance(tag, list | set | tuple):
+                content["tag"] = tag
+
+            elif isinstance(tag, str):
+                try:
+                    content["tag"] = parse_tag_expression(tag)
+
+                except ValueError:
+                    logger.warning(
+                        "NOTIFY - %s - Ignored invalid tag specified (type %s): %s",
+                        request.META["REMOTE_ADDR"],
+                        str(type(tag)),
+                        str(tag)[:12],
+                    )
+
+                    status = ResponseCode.bad_request
+                    msg = _("Unsupported characters found in tag definition")
+                    return (
+                        HttpResponse(msg, status=status, content_type="text/plain")
+                        if not json_response
+                        else JsonResponse(
+                            {
+                                "error": msg,
+                            },
+                            encoder=JSONEncoder,
+                            safe=False,
+                            status=status,
+                        )
+                    )
+
+            else:
+                logger.warning(
+                    "NOTIFY - %s - Ignored invalid tag specified (type %s): %s",
+                    request.META["REMOTE_ADDR"],
+                    str(type(tag)),
+                    str(tag)[:12],
+                )
+
+                status = ResponseCode.bad_request
+                msg = _("Unsupported characters found in tag definition")
+                return (
+                    HttpResponse(msg, status=status, content_type="text/plain")
+                    if not json_response
+                    else JsonResponse(
+                        {
+                            "error": msg,
+                        },
+                        encoder=JSONEncoder,
+                        safe=False,
+                        status=status,
+                    )
+                )
+
+        #
         # Allow 'format' value to be specified as part of the URL
         # parameters if not found otherwise defined.
         #
@@ -2135,7 +2292,7 @@ class StatelessNotifyView(View):
                 content.get("body"),
                 title=content.get("title", ""),
                 notify_type=content.get("type", apprise.NotifyType.INFO.value),
-                tag="all",
+                tag=(content.get("tag") or "all"),
                 attach=attach,
             )
 
@@ -2314,19 +2471,30 @@ class JsonUrlView(View):
         a_obj.add(ac_obj)
 
         for notification in a_obj.find(tag):
+            details = sorted(
+                [tag_detail(t) for t in notification.tags],
+                key=lambda item: (item["name"], item["priority"]),
+            )
+            url = notification.url(privacy=privacy)
+            retry = service_retry(notification, url)
+            optional = service_optional(notification, url)
+
             # Set Notification
             response["urls"].append(
                 {
                     "id": notification.url_id(),
                     "service_name": str(notification.service_name) if notification.service_name else "",
                     "enabled": bool(notification.enabled),
-                    "url": notification.url(privacy=privacy),
-                    "tags": notification.tags,
+                    "url": url,
+                    "retry": retry,
+                    "optional": optional,
+                    "tags": sorted(tag_names(notification.tags)),
+                    "tag_details": details,
                 }
             )
 
             # Store Tags
-            response["tags"] |= notification.tags
+            response["tags"] |= tag_names(notification.tags)
 
         # Return our retrieved content
         return JsonResponse(response, encoder=JSONEncoder, safe=False, status=ResponseCode.okay)

--- a/apprise_api/runserver.py
+++ b/apprise_api/runserver.py
@@ -1,0 +1,41 @@
+import argparse
+import re
+import subprocess
+import sys
+
+BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--branch")
+    return parser.parse_known_args(argv)
+
+
+def install_apprise_branch(branch):
+    if not BRANCH_RE.match(branch):
+        raise ValueError("Apprise branch names may only contain letters, numbers, '.', '_', '-', and '/'.")
+
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "--no-deps",
+            f"git+https://github.com/caronc/apprise.git@{branch}",
+        ]
+    )
+
+
+def main(argv=None):
+    options, runserver_args = parse_args(sys.argv[1:] if argv is None else argv)
+    if options.branch:
+        install_apprise_branch(options.branch)
+
+    return subprocess.call([sys.executable, "manage.py", "runserver", *runserver_args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apprise_api/runserver.py
+++ b/apprise_api/runserver.py
@@ -1,4 +1,7 @@
 import argparse
+from importlib import metadata
+import json
+from pathlib import Path
 import re
 import subprocess
 import sys
@@ -23,8 +26,40 @@ def install_apprise_branch(branch):
             "pip",
             "install",
             "--force-reinstall",
+            "--no-cache-dir",
             "--no-deps",
             f"git+https://github.com/caronc/apprise.git@{branch}",
+        ]
+    )
+
+
+def apprise_is_vcs_installed():
+    try:
+        dist = metadata.distribution("apprise")
+    except metadata.PackageNotFoundError:
+        return False
+
+    direct_url = Path(dist.locate_file("direct_url.json"))
+    if not direct_url.is_file():
+        return False
+
+    try:
+        return "vcs_info" in json.loads(direct_url.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+
+
+def install_apprise_pypi():
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "--no-cache-dir",
+            "--no-deps",
+            "apprise",
         ]
     )
 
@@ -33,6 +68,8 @@ def main(argv=None):
     options, runserver_args = parse_args(sys.argv[1:] if argv is None else argv)
     if options.branch:
         install_apprise_branch(options.branch)
+    elif apprise_is_vcs_installed():
+        install_apprise_pypi()
 
     return subprocess.call([sys.executable, "manage.py", "runserver", *runserver_args])
 

--- a/apprise_api/static/css/base.css
+++ b/apprise_api/static/css/base.css
@@ -1165,8 +1165,51 @@ body .tabs .tab.disabled a:hover i {
   font-weight: 600;
 }
 
+#notify .chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.28rem;
+  min-height: 3rem;
+}
+
+#notify .chips input {
+  min-width: 8rem;
+}
+
+#notify .chips .chip.notify-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 1.88rem;
+  margin: 0.12rem 0.12rem 0.12rem 0;
+  padding: 0 0.5rem 0 0.58rem;
+  border-radius: 999px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
+
+#notify .chips .chip.notify-tag-chip::before {
+  content: "🏷️";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  font-size: 0.78rem;
+  line-height: 1;
+}
+
+#notify .chips .chip.notify-tag-chip .close {
+  margin-left: 0.16rem;
+  margin-right: -0.1rem;
+  font-size: 1rem;
+  line-height: 1;
+  opacity: 0.66;
+}
+
 #url-list .card-panel .url-selected-icon {
-  position: static;
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1187,6 +1230,83 @@ body .tabs .tab.disabled a:hover i {
   font-size: 1.16rem;
   line-height: 1.16rem;
   display: block;
+}
+
+#url-list .card-panel .review-group-badge {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -52%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1rem;
+  height: 1rem;
+  padding: 0 0.18rem;
+  border: 1px solid var(--review-priority-badge-ring);
+  border-radius: 999px;
+  background: var(--review-priority-badge-bg);
+  color: var(--review-priority-badge-text);
+  font-size: 0.62rem;
+  font-weight: 800;
+  line-height: 1;
+  text-align: center;
+  box-shadow:
+    0 0 0 2px var(--review-priority-badge-halo),
+    0 2px 5px var(--review-priority-badge-shadow);
+}
+
+#url-list .card-panel .review-group-badge:empty {
+  display: none;
+}
+
+#url-list .card-panel .review-retry-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.8rem;
+  height: 1rem;
+  padding: 0 0.34rem;
+  border: 1px solid var(--review-retry-badge-ring);
+  border-radius: 999px;
+  background: var(--review-retry-badge-bg);
+  color: var(--review-retry-badge-text);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  box-shadow:
+    0 0 0 2px var(--review-retry-badge-halo),
+    0 1px 3px var(--review-retry-badge-shadow);
+}
+
+#url-list .card-panel .review-retry-badge:empty {
+  display: none;
+}
+
+#url-list .card-panel:not(.selected) .review-retry-badge {
+  opacity: 0.62;
+}
+
+#url-list .card-panel .review-optional-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1px solid var(--review-optional-badge-ring);
+  border-radius: 999px;
+  background: var(--review-optional-badge-bg);
+  color: var(--review-optional-badge-text);
+  font-size: 0.88rem;
+  line-height: 1;
+  box-shadow:
+    0 0 0 2px var(--review-optional-badge-halo),
+    0 1px 3px var(--review-optional-badge-shadow);
+}
+
+#url-list .card-panel:not(.selected) .review-optional-badge {
+  opacity: 0.68;
 }
 
 #url-list .card-panel .url-disabled-indicator {
@@ -1707,10 +1827,93 @@ code.config-id {
   overflow-x: hidden;
 }
 
+#notify .autocomplete-content {
+  scrollbar-width: thin;
+  scrollbar-color: var(--review-autocomplete-scroll-thumb) var(--review-autocomplete-scroll-track);
+  height: auto !important;
+  max-height: min(18rem, 52vh);
+  padding: 0.18rem 0.32rem 0.34rem;
+  box-sizing: border-box;
+}
+
+#notify .autocomplete-content::-webkit-scrollbar {
+  width: 0.55rem;
+}
+
+#notify .autocomplete-content::-webkit-scrollbar-track {
+  background: var(--review-autocomplete-scroll-track);
+  border-radius: 999px;
+}
+
+#notify .autocomplete-content::-webkit-scrollbar-thumb {
+  background: var(--review-autocomplete-scroll-thumb);
+  border: 2px solid var(--review-autocomplete-scroll-track);
+  border-radius: 999px;
+}
+
 #notify .notify-top-row .dropdown-content.select-dropdown li>span {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+#notify .autocomplete-content li:not(.notify-tag-option-exact)>span {
+  padding-left: 0.7rem;
+  padding-right: 0.7rem;
+}
+
+#notify .autocomplete-content li:not(.notify-tag-option-exact):hover>span,
+#notify .autocomplete-content li:not(.notify-tag-option-exact).active>span,
+#notify .autocomplete-content li:not(.notify-tag-option-exact).selected>span {
+  background: var(--review-autocomplete-hover-bg) !important;
+  color: var(--review-autocomplete-hover-text) !important;
+}
+
+#notify .autocomplete-content li.notify-tag-option-exact {
+  display: inline-flex;
+  align-items: center;
+  clear: none;
+  width: auto;
+  min-height: 0;
+  margin: -0.08rem 0.22rem 0.46rem 0;
+  background: transparent !important;
+  line-height: 1;
+  vertical-align: top;
+}
+
+#notify .autocomplete-content li.notify-tag-option-exact:hover,
+#notify .autocomplete-content li.notify-tag-option-exact.active,
+#notify .autocomplete-content li.notify-tag-option-exact.selected {
+  background: transparent !important;
+}
+
+#notify .autocomplete-content li.notify-tag-option-exact>span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.7rem;
+  max-width: 5.5rem;
+  padding: 0.32rem 0.56rem;
+  border: 1px solid var(--review-priority-option-ring);
+  border-radius: 999px;
+  background: var(--review-priority-option-bg) !important;
+  color: var(--review-priority-option-text) !important;
+  font-size: 0.84rem;
+  font-weight: 700;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.96;
+}
+
+#notify .autocomplete-content li.notify-tag-option-exact:hover>span,
+#notify .autocomplete-content li.notify-tag-option-exact.active>span {
+  background: var(--review-priority-option-hover-bg) !important;
+  color: var(--review-priority-option-hover-text) !important;
+}
+
+#notify .autocomplete-content .notify-tag-option-token-text {
+  display: none;
 }
 
 @media (max-width: 992px) {

--- a/apprise_api/static/css/base.css
+++ b/apprise_api/static/css/base.css
@@ -833,6 +833,14 @@ Welcome Page Collapsibles
   margin: 0;
 }
 
+.loaded-config-heading-meta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  flex-shrink: 0;
+}
+
 .loaded-config-heading-status {
   margin: 0;
   flex-shrink: 0;
@@ -854,6 +862,84 @@ Welcome Page Collapsibles
 .loaded-config-heading-status-text .card-count {
   margin-left: 0;
   font-weight: 800;
+}
+
+.review-selected-filter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 1.55rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.review-selected-filter input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.review-selected-filter-track {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 3rem;
+  height: 1.55rem;
+  border: 1px solid var(--review-filter-toggle-ring);
+  border-radius: 999px;
+  background: var(--review-filter-toggle-bg);
+  padding-left: 0 !important;
+  box-shadow: inset 0 1px 3px var(--review-filter-toggle-inner-shadow);
+  transition: background 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.review-selected-filter input+.review-selected-filter-track::before,
+.review-selected-filter input+.review-selected-filter-track::after {
+  content: none !important;
+  display: none !important;
+}
+
+.review-selected-filter-knob {
+  position: absolute;
+  left: 0.18rem;
+  top: 50%;
+  width: 1.12rem;
+  height: 1.12rem;
+  border-radius: 999px;
+  background: var(--review-filter-toggle-knob);
+  box-shadow: 0 1px 4px var(--review-filter-toggle-shadow);
+  transform: translateY(-50%);
+  transition: transform 0.16s ease, background 0.16s ease;
+}
+
+.review-selected-filter input:checked+.review-selected-filter-track {
+  border-color: var(--review-filter-toggle-active-ring);
+  background: var(--review-filter-toggle-active-bg);
+  box-shadow:
+    inset 0 1px 3px var(--review-filter-toggle-inner-shadow),
+    0 0 0 2px var(--review-filter-toggle-active-halo);
+}
+
+.review-selected-filter input:checked+.review-selected-filter-track .review-selected-filter-knob {
+  transform: translate(1.42rem, -50%);
+  background: var(--review-filter-toggle-active-knob);
+}
+
+.review-selected-filter input:focus-visible+.review-selected-filter-track {
+  outline: 2px solid var(--review-filter-toggle-focus);
+  outline-offset: 2px;
+}
+
+.review-selected-filter:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .loaded-config-tip {
@@ -903,6 +989,11 @@ Welcome Page Collapsibles
 
   .loaded-config-heading-status-text {
     white-space: normal;
+  }
+
+  .loaded-config-heading-meta {
+    align-self: stretch;
+    justify-content: flex-start;
   }
 
   .loaded-config-tip {
@@ -1072,6 +1163,10 @@ body .tabs .tab.disabled a:hover i {
 
 #url-list .card-panel.url-item-disabled {
   cursor: not-allowed;
+}
+
+#url-list .card-panel.review-filter-hidden {
+  display: none;
 }
 
 #url-list .card-panel.url-item-disabled .chip {

--- a/apprise_api/static/css/theme-dark.css
+++ b/apprise_api/static/css/theme-dark.css
@@ -276,6 +276,31 @@ Side Nav
   --apprise-mini-badge-ring: #0b3b37;
   --apprise-mini-badge-horn: #f2f8f8;
   --apprise-mini-badge-horn-stroke: #c8d6d5;
+  --review-priority-badge-bg: #ffd166;
+  --review-priority-badge-text: #17181c;
+  --review-priority-badge-ring: #ffe7a3;
+  --review-priority-badge-halo: rgba(23, 24, 28, 0.78);
+  --review-priority-badge-shadow: rgba(0, 0, 0, 0.55);
+  --review-retry-badge-bg: #34383f;
+  --review-retry-badge-text: #edeef3;
+  --review-retry-badge-ring: #555a62;
+  --review-retry-badge-halo: rgba(23, 24, 28, 0.72);
+  --review-retry-badge-shadow: rgba(0, 0, 0, 0.46);
+  --review-optional-badge-bg: #274d55;
+  --review-optional-badge-text: #aaf3eb;
+  --review-optional-badge-ring: #40737d;
+  --review-optional-badge-halo: rgba(23, 24, 28, 0.72);
+  --review-optional-badge-shadow: rgba(0, 0, 0, 0.42);
+  --review-autocomplete-scroll-track: #23262f;
+  --review-autocomplete-scroll-thumb: #555a62;
+  --review-autocomplete-section-border: #3f4552;
+  --review-autocomplete-hover-bg: #34383f;
+  --review-autocomplete-hover-text: #7de6da;
+  --review-priority-option-bg: #253f43;
+  --review-priority-option-text: #7de6da;
+  --review-priority-option-ring: #346c68;
+  --review-priority-option-hover-bg: #0b3b37;
+  --review-priority-option-hover-text: #b8fff7;
   --apprise-logo-wave: #89a0a5;
   --apprise-logo-body-1: #4ed1c8;
   --apprise-logo-body-2: #1f8780;
@@ -770,6 +795,17 @@ Buttons & Chips
 .chip.selected {
   color: #ffffff;
   background-color: #148c80 !important;
+}
+
+#notify .chips .chip.notify-tag-chip {
+  color: #ffffff;
+  background-color: #148c80 !important;
+  border-color: #2cb6a6 !important;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.32);
+}
+
+#notify .chips .chip.notify-tag-chip .close {
+  color: inherit;
 }
 
 .url-selected-icon i {

--- a/apprise_api/static/css/theme-dark.css
+++ b/apprise_api/static/css/theme-dark.css
@@ -161,6 +161,19 @@ Status & Indicators
   color: #cffff9;
 }
 
+:root {
+  --review-filter-toggle-bg: #23262f;
+  --review-filter-toggle-ring: #3f4552;
+  --review-filter-toggle-knob: #aeb4be;
+  --review-filter-toggle-shadow: rgba(0, 0, 0, 0.42);
+  --review-filter-toggle-inner-shadow: rgba(0, 0, 0, 0.32);
+  --review-filter-toggle-active-bg: #0b3b37;
+  --review-filter-toggle-active-ring: #2f7f77;
+  --review-filter-toggle-active-knob: #7de6da;
+  --review-filter-toggle-active-halo: rgba(45, 182, 166, 0.18);
+  --review-filter-toggle-focus: #7de6da;
+}
+
 .loaded-config-tip {
   background-color: #23262f;
   border-color: #34383f;

--- a/apprise_api/static/css/theme-light.css
+++ b/apprise_api/static/css/theme-light.css
@@ -138,6 +138,19 @@ Status & Indicators
   color: #0f5f57;
 }
 
+:root {
+  --review-filter-toggle-bg: #e6e9ef;
+  --review-filter-toggle-ring: #c7ccd5;
+  --review-filter-toggle-knob: #ffffff;
+  --review-filter-toggle-shadow: rgba(34, 42, 55, 0.18);
+  --review-filter-toggle-inner-shadow: rgba(34, 42, 55, 0.12);
+  --review-filter-toggle-active-bg: #c8f0ea;
+  --review-filter-toggle-active-ring: #39c0b7;
+  --review-filter-toggle-active-knob: #0f5f57;
+  --review-filter-toggle-active-halo: rgba(57, 192, 183, 0.2);
+  --review-filter-toggle-focus: #148c80;
+}
+
 .loaded-config-tip {
   background-color: #f6f7fa;
   border-color: #d8d9df;

--- a/apprise_api/static/css/theme-light.css
+++ b/apprise_api/static/css/theme-light.css
@@ -537,6 +537,31 @@ Side Nav
   --apprise-mini-badge-ring: #0f5f57;
   --apprise-mini-badge-horn: #eaf3f2;
   --apprise-mini-badge-horn-stroke: #c5d2d0;
+  --review-priority-badge-bg: #ffd166;
+  --review-priority-badge-text: #23262f;
+  --review-priority-badge-ring: #b98500;
+  --review-priority-badge-halo: rgba(255, 255, 255, 0.86);
+  --review-priority-badge-shadow: rgba(34, 42, 55, 0.24);
+  --review-retry-badge-bg: #e3e8ee;
+  --review-retry-badge-text: #34383f;
+  --review-retry-badge-ring: #aeb7c4;
+  --review-retry-badge-halo: rgba(255, 255, 255, 0.68);
+  --review-retry-badge-shadow: rgba(34, 42, 55, 0.16);
+  --review-optional-badge-bg: #dff3ef;
+  --review-optional-badge-text: #0f5f57;
+  --review-optional-badge-ring: #8dd4cb;
+  --review-optional-badge-halo: rgba(255, 255, 255, 0.68);
+  --review-optional-badge-shadow: rgba(34, 42, 55, 0.14);
+  --review-autocomplete-scroll-track: #eef2f6;
+  --review-autocomplete-scroll-thumb: #aeb7c4;
+  --review-autocomplete-section-border: #d9e0e8;
+  --review-autocomplete-hover-bg: #e8f7f4;
+  --review-autocomplete-hover-text: #0f5f57;
+  --review-priority-option-bg: #e8f7f4;
+  --review-priority-option-text: #0f5f57;
+  --review-priority-option-ring: #8dd4cb;
+  --review-priority-option-hover-bg: #c8f0ea;
+  --review-priority-option-hover-text: #0b4d47;
   --apprise-logo-wave: #9fb0b3;
   --apprise-logo-body-1: #39c0b7;
   --apprise-logo-body-2: #0f5f57;
@@ -705,6 +730,17 @@ Buttons & Chips
 .chip.selected {
   background-color: #148c80 !important;
   color: #ffffff !important;
+}
+
+#notify .chips .chip.notify-tag-chip {
+  background-color: #148c80 !important;
+  border-color: #0f5f57 !important;
+  color: #ffffff !important;
+  box-shadow: 0 1px 3px rgba(34, 42, 55, 0.14);
+}
+
+#notify .chips .chip.notify-tag-chip .close {
+  color: inherit;
 }
 
 .file-selected {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -475,6 +475,10 @@ components:
           $ref: '#/components/schemas/NotificationFormat'
         tag:
           type: string
+          description: >
+            Optional Apprise tag expression. Supports tag, priority:tag,
+            tag:retry, and priority:tag:retry tokens. Comma or pipe separates
+            OR groups; whitespace, ampersand, or plus separates AND terms.
       required:
         - body
 
@@ -557,6 +561,10 @@ components:
         tag:
           type: string
           default: all
+          description: >
+            Optional Apprise tag expression. Supports tag, priority:tag,
+            tag:retry, and priority:tag:retry tokens. Comma or pipe separates
+            OR groups; whitespace, ampersand, or plus separates AND terms.
       required:
         - body
 
@@ -573,6 +581,10 @@ components:
           $ref: '#/components/schemas/NotificationFormat'
         tag:
           type: string
+          description: >
+            Optional Apprise tag expression. Supports tag, priority:tag,
+            tag:retry, and priority:tag:retry tokens. Comma or pipe separates
+            OR groups; whitespace, ampersand, or plus separates AND terms.
         attach:
           type: array
           items:
@@ -594,6 +606,10 @@ components:
           $ref: '#/components/schemas/NotificationFormat'
         tag:
           type: string
+          description: >
+            Optional Apprise tag expression. Supports tag, priority:tag,
+            tag:retry, and priority:tag:retry tokens. Comma or pipe separates
+            OR groups; whitespace, ampersand, or plus separates AND terms.
       required:
         - body
 
@@ -602,6 +618,7 @@ components:
       properties:
         tags:
           type: array
+          description: Bare tag names available in this configuration.
           items:
             type: string
         urls:
@@ -614,9 +631,34 @@ components:
       properties:
         id:
           type: string
+        service_name:
+          type: string
+        enabled:
+          type: boolean
         url:
           type: string
+        retry:
+          type: integer
+          description: Configured retry count for this URL.
+        optional:
+          type: boolean
+          description: Whether failures from this URL are ignored when determining notification success.
         tags:
           type: array
+          description: Bare tag names associated with this URL.
           items:
             type: string
+        tag_details:
+          type: array
+          description: Structured tag metadata, including priority-aware exact tokens.
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              priority:
+                type: integer
+              token:
+                type: string
+              exact:
+                type: string

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ setenv =
     APPRISE_STATEFUL_MODE = {env:APPRISE_STATEFUL_MODE:simple}
 deps = .[dev]
 commands =
-    python manage.py runserver {posargs}
+    python -m apprise_api.runserver {posargs}
 
 [testenv:shell]
 description = Run Django development shell (manage.py shell)


### PR DESCRIPTION
## Description
Related issue/PR: https://github.com/caronc/apprise/pull/1601

This PR updates Apprise API to better understand and present Apprise core's new `retry`, `optional`, and priority/escalation tag behavior.

- Priority-aware tags such as `1:alerts`, while preserving existing plain tag behavior like `alerts`.
- Retry indicators for configured retry attempts, including tag-level retry overrides.
- Optional-service indicators for URLs where failures should not affect the overall notification result.
- A Review tab experience that clearly shows escalation groups, retries, optional services, and selected targets.
- A Notification tab tag selector that supports priority-specific targeting only when it is useful.
- A development `runserver` workflow that can test Apprise API against a specific Apprise core branch.

The goal is to keep existing Apprise API behavior backwards compatible while making the new advanced Apprise routing behavior visible and easier to test.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/55](https://github.com/caronc/apprise-docs/pull/55)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
Anyone can help test as follows:

```bash
# Clone the branch
git clone -b priority-retry-escalations https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run lint checks
tox -e lint

# Run a local instance of the API at http://localhost:8000
# using the matching Apprise core branch
tox -e runserver -- --branch=master
```

To confirm the default PyPI Apprise workflow still works:

```bash
# Run without --branch to restore/use the PyPI Apprise package
tox -e runserver
```
