### PR TITLE
Timezone alignment between Nginx and Gunicorn allowing dates alignment

### DIFF
--- a/apprise_api/api/tests/test_gunicorn_conf.py
+++ b/apprise_api/api/tests/test_gunicorn_conf.py
@@ -1,0 +1,120 @@
+#
+# Copyright (C) 2026 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import importlib.util
+import os
+import sys
+import types
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+# Absolute path to gunicorn.conf.py relative to this test file:
+#   apprise_api/api/tests/ -> ../../ -> apprise_api/
+_GUNICORN_CONF_PATH = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "gunicorn.conf.py"))
+
+
+def _load_gunicorn_conf(extra_env=None):
+    """
+    Execute gunicorn.conf.py as a fresh module inside a controlled environment.
+    Returns a ``(module, tzset_call_count)`` tuple so callers can assert on the
+    number of times ``time.tzset()`` was invoked during module load.
+
+    Each call gets a clean import so module-level side-effects (like the
+    ``time.tzset()`` call) are re-executed.  ``extra_env`` overlays the minimal
+    base environment; omitting ``TZ`` exercises the ``Etc/UTC`` default path.
+    """
+    env = {
+        "DJANGO_SETTINGS_MODULE": "core.settings",
+        "LANG": "en_US.UTF-8",
+    }
+    if extra_env:
+        env.update(extra_env)
+
+    # Discard any cached copy so the module body always re-runs on load.
+    sys.modules.pop("gunicorn_conf", None)
+
+    spec = importlib.util.spec_from_file_location("gunicorn_conf", _GUNICORN_CONF_PATH)
+    assert spec is not None and spec.loader is not None, f"Could not load spec from {_GUNICORN_CONF_PATH}"
+    module = importlib.util.module_from_spec(spec)
+
+    with mock.patch.dict(os.environ, env, clear=True), mock.patch("time.tzset") as mock_tzset:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        tzset_call_count = mock_tzset.call_count
+
+    return module, tzset_call_count
+
+
+class GunicornConfTzTests(SimpleTestCase):
+    """
+    Verify that gunicorn.conf.py correctly propagates the TZ environment
+    variable so that Python's logging timestamps stay consistent with the
+    timezone established by supervisord-startup.
+    """
+
+    def test_tz_general(self):
+        """TZ is forwarded into raw_env and time.tzset() fires at import time."""
+        mod, tzset_calls = _load_gunicorn_conf(extra_env={"TZ": "America/New_York"})
+
+        tz_entries = [e for e in mod.raw_env if e.startswith("TZ=")]
+        self.assertEqual(len(tz_entries), 1, "Exactly one TZ entry expected in raw_env")
+        self.assertEqual(tz_entries[0], "TZ=America/New_York")
+
+        # The module-level tzset() must fire before any worker is forked so the
+        # master process itself uses the correct timezone.
+        self.assertGreater(tzset_calls, 0)
+
+    def test_tz_default(self):
+        """TZ defaults to Etc/UTC when the environment variable is not present."""
+        mod, _ = _load_gunicorn_conf()  # TZ intentionally absent from env
+
+        tz_entries = [e for e in mod.raw_env if e.startswith("TZ=")]
+        self.assertEqual(len(tz_entries), 1)
+        self.assertEqual(tz_entries[0], "TZ=Etc/UTC")
+
+    def test_tz_utc_explicit(self):
+        """An explicit TZ=Etc/UTC passes through raw_env unchanged."""
+        mod, _ = _load_gunicorn_conf(extra_env={"TZ": "Etc/UTC"})
+
+        tz_entries = [e for e in mod.raw_env if e.startswith("TZ=")]
+        self.assertEqual(tz_entries[0], "TZ=Etc/UTC")
+
+    def test_post_fork_calls_tzset(self):
+        """post_fork() must call time.tzset() to re-initialise timezone state in each worker."""
+        mod, _ = _load_gunicorn_conf()
+
+        with mock.patch("time.tzset") as mock_tzset:
+            mod.post_fork(None, None)
+
+        mock_tzset.assert_called_once()
+
+    def test_post_fork_skipped_when_no_tzset(self):
+        """post_fork() must not raise on platforms where time.tzset() is unavailable (e.g. Windows)."""
+        mod, _ = _load_gunicorn_conf()
+
+        # Replace the module's reference to `time` with a namespace that has no
+        # tzset attribute so the hasattr() guard inside post_fork() is exercised.
+        mock_time = types.SimpleNamespace()  # intentionally has no tzset
+        with mock.patch.dict(mod.__dict__, {"time": mock_time}):
+            mod.post_fork(None, None)  # must not raise

--- a/apprise_api/gunicorn.conf.py
+++ b/apprise_api/gunicorn.conf.py
@@ -37,8 +37,7 @@ if hasattr(time, "tzset"):
 raw_env = [
     "LANG={}".format(os.environ.get("LANG", "en_US.UTF-8")),
     "DJANGO_SETTINGS_MODULE=core.settings",
-    # Carry the resolved TZ into every worker so Python's logging formatter
-    # uses the same timezone as nginx (which reads /etc/localtime directly).
+    # Carry TZ into every worker environment.
     "TZ={}".format(os.environ.get("TZ", "Etc/UTC")),
 ]
 
@@ -79,7 +78,8 @@ loglevel = "warn"
 
 
 def post_fork(_server, _worker):
-    # Re-apply TZ in each worker after fork so Python's time functions
-    # (used by the logging formatter) use the same timezone as nginx.
+    # Re-apply TZ in each worker after the fork.
+    # to ensure each forked worker initialises from the TZ env var rather than
+    # from whatever state it inherited from the parent.
     if hasattr(time, "tzset"):
         time.tzset()

--- a/apprise_api/gunicorn.conf.py
+++ b/apprise_api/gunicorn.conf.py
@@ -78,8 +78,8 @@ loglevel = "warn"
 
 
 def post_fork(_server, _worker):
-    # Re-apply TZ in each worker after the fork.
-    # to ensure each forked worker initialises from the TZ env var rather than
-    # from whatever state it inherited from the parent.
+    # Re-apply TZ in each worker after the fork to ensure each freshly forked
+    # worker initialises from the TZ env var rather than from whatever cached
+    # timezone state it inherited from the parent process.
     if hasattr(time, "tzset"):
         time.tzset()

--- a/apprise_api/supervisord-startup
+++ b/apprise_api/supervisord-startup
@@ -24,20 +24,25 @@
 
 # Timezone setup: align every process in the container to the same timezone
 # so that log timestamps from nginx, gunicorn, and Python all agree.
-
-# - TZ is the single source of truth.  If the caller does not supply it, it
-# defaults to Etc/UTC.
-# - IF TZ is resolved it is exported (so every child process inherits it) and
-# /etc/localtime is updated to point at the matching zoneinfo file. This is
-# to keep nginx in sync with gunicorn
-# - The container works correctly in non-root mode as well as  no write access
-# to /etc/localtime is required.
-# - /etc/localtime is only updated as a secondary best-effort measure so that
-# any third-party tool that reads the timezone file directly (rather than going
-# through localtime()) also stays in sync.  This step is silently skipped when
-# the container runs as a non-root user; it has no effect on Apprise-API itself
-# (specifically Nginx or Python/Gunicorn)
 #
+# TZ is the single source of truth.  If not supplied it defaults to Etc/UTC,
+# matching the Dockerfile default.  Exporting TZ before supervisord starts is
+# sufficient: both Python (via time.tzset() in gunicorn.conf.py) and nginx
+# (via the C library's localtime(), which checks TZ before falling back to
+# /etc/localtime) inherit it from their parent process.  The container works
+# correctly in non-root mode for exactly this reason — no file-system write is
+# required for timezone handling to take effect.
+#
+# Note: users who previously relied on bind-mounting the host's /etc/localtime
+# or /etc/timezone to propagate the host timezone without setting TZ should now
+# pass TZ explicitly (e.g. -e TZ=America/New_York) to guarantee consistent
+# behaviour across all processes.
+#
+# /etc/localtime and /etc/timezone are also updated as a secondary best-effort
+# measure so that any tool that reads those files directly (bypassing the C
+# library's localtime()) also sees the correct zone.  Both writes are silently
+# skipped when the container runs as a non-root user; this has no effect on
+# nginx or Python, which read TZ from the environment.
 TZ="${TZ:-Etc/UTC}"
 export TZ
 

--- a/apprise_api/supervisord-startup
+++ b/apprise_api/supervisord-startup
@@ -22,36 +22,31 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Timezone setup: ensure all processes (nginx, gunicorn, Python logging) use
-# the same timezone so log timestamps are always aligned.
+# Timezone setup: align every process in the container to the same timezone
+# so that log timestamps from nginx, gunicorn, and Python all agree.
+
+# - TZ is the single source of truth.  If the caller does not supply it, it
+# defaults to Etc/UTC.
+# - IF TZ is resolved it is exported (so every child process inherits it) and
+# /etc/localtime is updated to point at the matching zoneinfo file. This is
+# to keep nginx in sync with gunicorn
+# - The container works correctly in non-root mode as well as  no write access
+# to /etc/localtime is required.
+# - /etc/localtime is only updated as a secondary best-effort measure so that
+# any third-party tool that reads the timezone file directly (rather than going
+# through localtime()) also stays in sync.  This step is silently skipped when
+# the container runs as a non-root user; it has no effect on Apprise-API itself
+# (specifically Nginx or Python/Gunicorn)
 #
-# When TZ is set it is the authority: /etc/localtime is updated to match so
-# that C programs such as nginx, which read the file directly, agree with
-# Python (which reads TZ via time.tzset() in gunicorn.conf.py).
-#
-# When TZ is not set it is derived from the environment in priority order:
-#   1. /etc/localtime symlink target  (common Docker host-timezone pattern)
-#   2. /etc/timezone                  (plain-file bind-mount fallback)
-# The derived name is exported as TZ so Python and nginx both pick it up.
-if [ -n "${TZ}" ]; then
-   if [ -f "/usr/share/zoneinfo/${TZ}" ]; then
-      echo "${TZ}" > /etc/timezone 2>/dev/null || true
-      echo "Timezone: ${TZ}"
-   else
-      echo "WARNING: TZ='${TZ}' is not a valid timezone name; timestamps may be inaccurate"
-   fi
-elif [ -L /etc/localtime ]; then
-   _tz=$(readlink /etc/localtime | sed 's|.*/zoneinfo/||')
-   if [ -n "${_tz}" ] && [ -f "/usr/share/zoneinfo/${_tz}" ]; then
-      export TZ="${_tz}"
-      echo "Timezone derived from /etc/localtime symlink: ${TZ}"
-   fi
-elif [ -f /etc/timezone ]; then
-   _tz=$(cat /etc/timezone 2>/dev/null | tr -d '[:space:]')
-   if [ -n "${_tz}" ] && [ -f "/usr/share/zoneinfo/${_tz}" ]; then
-      export TZ="${_tz}"
-      echo "Timezone derived from /etc/timezone: ${TZ}"
-   fi
+TZ="${TZ:-Etc/UTC}"
+export TZ
+
+if [ -f "/usr/share/zoneinfo/${TZ}" ]; then
+   ln -sf "/usr/share/zoneinfo/${TZ}" /etc/localtime 2>/dev/null || true
+   printf '%s\n' "${TZ}" > /etc/timezone 2>/dev/null || true
+   echo "Timezone: ${TZ}"
+else
+   echo "WARNING: TZ='${TZ}' not found in /usr/share/zoneinfo/; timestamps may be inaccurate"
 fi
 
 # Nginx configuration file


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #322 & #323

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/61](https://github.com/caronc/apprise-docs/pull/61)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b 322-timezone-fix-attempt-two https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
