### PR TITLE
Honor wire Content-Type for multipart attachment uploads

### DIFF
--- a/apprise_api/api/tests/test_attachment.py
+++ b/apprise_api/api/tests/test_attachment.py
@@ -564,3 +564,37 @@ class AttachmentTests(SimpleTestCase):
             # 2 (payload) + 2 (files) = 4 > max=3
             with self.assertRaises(ValueError):
                 parse_attachments(attachment_payload, files_request)
+
+    def test_form_file_attachment_parsing_honors_wire_content_type(self):
+        """
+        Multipart Content-Type should win over filename extension guessing.
+        """
+        with override_settings(APPRISE_ATTACH_DIR=self.tmp_dir.name):
+            files_request = {
+                "file1": SimpleUploadedFile(
+                    "attachment.001",
+                    b"\xff\xd8\xff\xe0",
+                    content_type="image/jpeg",
+                )
+            }
+            result = parse_attachments(None, files_request)
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0].mimetype == "image/jpeg"
+
+    def test_form_file_attachment_parsing_octet_stream_falls_back_to_filename(self):
+        """
+        Django's "application/octet-stream" default must not suppress filename guessing.
+        """
+        with override_settings(APPRISE_ATTACH_DIR=self.tmp_dir.name):
+            files_request = {
+                "file1": SimpleUploadedFile(
+                    "poster.jpg",
+                    b"\xff\xd8\xff\xe0",
+                    content_type="application/octet-stream",
+                )
+            }
+            result = parse_attachments(None, files_request)
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0].mimetype == "image/jpeg"

--- a/apprise_api/api/tests/test_attachment.py
+++ b/apprise_api/api/tests/test_attachment.py
@@ -598,3 +598,37 @@ class AttachmentTests(SimpleTestCase):
             assert isinstance(result, list)
             assert len(result) == 1
             assert result[0].mimetype == "image/jpeg"
+
+    def test_form_file_attachment_parsing_normalizes_mixed_case_content_type(self):
+        """
+        Mixed-case Content-Type must be lowercased before reaching Apprise.
+        """
+        with override_settings(APPRISE_ATTACH_DIR=self.tmp_dir.name):
+            files_request = {
+                "file1": SimpleUploadedFile(
+                    "attachment.001",
+                    b"\xff\xd8\xff\xe0",
+                    content_type="Image/JPEG",
+                )
+            }
+            result = parse_attachments(None, files_request)
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0].mimetype == "image/jpeg"
+
+    def test_form_file_attachment_parsing_uppercase_octet_stream_falls_back_to_filename(self):
+        """
+        Uppercase "application/octet-stream" must still defer to filename guessing.
+        """
+        with override_settings(APPRISE_ATTACH_DIR=self.tmp_dir.name):
+            files_request = {
+                "file1": SimpleUploadedFile(
+                    "poster.jpg",
+                    b"\xff\xd8\xff\xe0",
+                    content_type="APPLICATION/OCTET-STREAM",
+                )
+            }
+            result = parse_attachments(None, files_request)
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0].mimetype == "image/jpeg"

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -423,9 +423,13 @@ def parse_attachments(attachment_payload, files_request):
         except (AttributeError, TypeError):
             raise ValueError(f"An invalid filename was provided for attachment {no}") from None
 
-        # Honor the wire Content-Type; octet-stream means "unset" here
-        wire_mimetype = getattr(meta, "content_type", None)
+        # lower() protects case from the Apprise case sensitive guessing:
+        #  - Content-Type: Image/JPEG
+        #  - APPLICATION/OCTET-STREAM
+        wire_mimetype = getattr(meta, "content_type", "").strip().lower() or None
+
         if wire_mimetype == "application/octet-stream":
+            # disabling mimetype before Attachment() object allows for guessing of type
             wire_mimetype = None
 
         attachment = Attachment(filename, mimetype=wire_mimetype)

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -423,10 +423,12 @@ def parse_attachments(attachment_payload, files_request):
         except (AttributeError, TypeError):
             raise ValueError(f"An invalid filename was provided for attachment {no}") from None
 
-        #
-        # Prepare our Attachment
-        #
-        attachment = Attachment(filename)
+        # Honor the wire Content-Type; octet-stream means "unset" here
+        wire_mimetype = getattr(meta, "content_type", None)
+        if wire_mimetype == "application/octet-stream":
+            wire_mimetype = None
+
+        attachment = Attachment(filename, mimetype=wire_mimetype)
         try:
             with open(attachment.path, "wb") as f:
                 # Write our content to disk


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #329

`parse_attachments` drops the multipart `Content-Type` header on `request.FILES` uploads. An image arriving as `Content-Type: image/jpeg` with an extensionless filename like `attachment.001` gets detected as `application/octet-stream` and rejected by Pushover and other strict-mimetype plugins.

This shows up any time an upstream client re-uploads attachments in FORM mode, including Apprise core's own `apprise_api` plugin, and it's why images get dropped on stateful `apprise://` notifications.

The fix uses the wire `Content-Type` when one is present, with a guard so that Django's default `application/octet-stream` (set when a multipart part has no `Content-Type` header at all) still falls back to filename-extension detection. Two tests cover both branches.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): NA
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b fix/multipart-content-type https://github.com/jamcalli/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
