### PR TITLE
Honor attachments plural alias in notify payloads

### DIFF
--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -1152,6 +1152,27 @@ class NotifyTests(SimpleTestCase):
         # Reset our mock object
         mock_notify.reset_mock()
 
+        # Preare our JSON data (and support attachments keyword as plural alias)
+        json_data = {
+            "body": "test message",
+            "format": None,
+            "attachments": "https://localhost/invalid/path/to/image.png",
+        }
+
+        response = self.client.post(
+            "/notify/{}".format(key),
+            data=json.dumps(json_data),
+            content_type="application/json",
+        )
+
+        # We failed to send notification because we couldn't fetch the
+        # attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        # Reset our mock object
+        mock_notify.reset_mock()
+
         json_data = {
             "body": "test message",
         }

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -982,6 +982,21 @@ class NotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Preare our form data
+        form_data = {
+            "body": "test notifiction",
+            "attachments": "https://localhost/invalid/path/to/image.png",
+        }
+
+        # Send our notification
+        response = self.client.post("/notify/{}".format(key), form_data)
+        # We fail because we couldn't retrieve our attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
     @mock.patch("apprise.Apprise.notify")
     def test_notify_by_loaded_urls_with_json(self, mock_notify):
         """
@@ -1152,7 +1167,6 @@ class NotifyTests(SimpleTestCase):
         # Reset our mock object
         mock_notify.reset_mock()
 
-        # Preare our JSON data (and support attachments keyword as plural alias)
         json_data = {
             "body": "test message",
             "format": None,

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -997,6 +997,21 @@ class NotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Verify each alias alone (no body) routes to Bad Attachment, not the
+        # minimum-requirements gate — confirming attach-only payloads are valid.
+        for _alias in ("attach", "attachment", "attachments"):
+            form_data = {
+                _alias: "https://localhost/invalid/path/to/image.png",
+            }
+            response = self.client.post("/notify/{}".format(key), form_data)
+            assert response.status_code == 400
+            assert b"Bad Attachment" in response.content
+            assert mock_notify.call_count == 0
+            mock_notify.reset_mock()
+
     @mock.patch("apprise.Apprise.notify")
     def test_notify_by_loaded_urls_with_json(self, mock_notify):
         """
@@ -1186,6 +1201,24 @@ class NotifyTests(SimpleTestCase):
 
         # Reset our mock object
         mock_notify.reset_mock()
+
+        # Test every alias alone (no body) via JSON to confirm attach-only
+        # payloads are accepted and resolve to Bad Attachment, not the
+        # minimum-requirements gate.  Also exercises the 'attachment' canonical
+        # key path directly, which skips alias renaming.
+        for _alias in ("attach", "attachment", "attachments"):
+            json_data = {
+                _alias: "https://localhost/invalid/path/to/image.png",
+            }
+            response = self.client.post(
+                "/notify/{}".format(key),
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
+            assert response.status_code == 400
+            assert b"Bad Attachment" in response.content
+            assert mock_notify.call_count == 0
+            mock_notify.reset_mock()
 
         json_data = {
             "body": "test message",

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -484,6 +484,73 @@ class StatelessNotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Test the canonical 'attachment' key directly in a JSON body (with
+        # body present).  This exercises the no-op branch where the key is
+        # already canonical and requires no renaming.
+        json_data = {
+            "body": "test notifiction",
+            "urls": ", ".join(
+                [
+                    "mailto://user:pass@hotmail.com",
+                    "mailto://user:pass@gmail.com",
+                ]
+            ),
+            "attachment": "https://localhost/invalid/path/to/image.png",
+        }
+
+        response = self.client.post(
+            "/notify/",
+            data=json.dumps(json_data),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert b"Bad Attachment" in response.content
+        assert mock_notify.call_count == 0
+
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Verify all three aliases via form-data with no body present.
+        # The attachment handling must now run before the minimum-requirements
+        # check so that attach-only payloads reach Bad Attachment instead of
+        # "Payload lacks minimum requirements".
+        _urls = ", ".join(
+            [
+                "mailto://user:pass@hotmail.com",
+                "mailto://user:pass@gmail.com",
+            ]
+        )
+        for _alias in ("attach", "attachment", "attachments"):
+            form_data = {
+                "urls": _urls,
+                _alias: "https://localhost/invalid/path/to/image.png",
+            }
+            response = self.client.post("/notify", form_data)
+            assert response.status_code == 400
+            assert b"Bad Attachment" in response.content
+            assert mock_notify.call_count == 0
+            mock_notify.reset_mock()
+
+        # Same coverage via JSON body (no body field) for all three aliases.
+        for _alias in ("attach", "attachment", "attachments"):
+            json_data = {
+                "urls": _urls,
+                _alias: "https://localhost/invalid/path/to/image.png",
+            }
+            response = self.client.post(
+                "/notify/",
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
+            assert response.status_code == 400
+            assert b"Bad Attachment" in response.content
+            assert mock_notify.call_count == 0
+            mock_notify.reset_mock()
+
     @override_settings(APPRISE_RECURSION_MAX=1)
     @mock.patch("apprise.Apprise.notify")
     def test_stateless_notify_recursion(self, mock_notify):

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -438,6 +438,31 @@ class StatelessNotifyTests(SimpleTestCase):
         assert response.status_code == 400
         assert mock_notify.call_count == 0
 
+        # Reset our mock object
+        mock_notify.reset_mock()
+
+        # Preare our json data (and support attachments keyword as plural alias)
+        json_data = {
+            "body": "test notifiction",
+            "urls": ", ".join(
+                [
+                    "mailto://user:pass@hotmail.com",
+                    "mailto://user:pass@gmail.com",
+                ]
+            ),
+            "attachments": "https://localhost/invalid/path/to/image.png",
+        }
+
+        response = self.client.post(
+            "/notify/",
+            data=json.dumps(json_data),
+            content_type="application/json",
+        )
+
+        # We fail because we couldn't retrieve our attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
     @override_settings(APPRISE_RECURSION_MAX=1)
     @mock.patch("apprise.Apprise.notify")
     def test_stateless_notify_recursion(self, mock_notify):

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -415,6 +415,27 @@ class StatelessNotifyTests(SimpleTestCase):
         # Reset our mock object
         mock_notify.reset_mock()
 
+        # Preare our form data (support attachments keyword)
+        form_data = {
+            "body": "test notifiction",
+            "urls": ", ".join(
+                [
+                    "mailto://user:pass@hotmail.com",
+                    "mailto://user:pass@gmail.com",
+                ]
+            ),
+            "attachments": "https://localhost/invalid/path/to/image.png",
+        }
+
+        # Send our notification
+        response = self.client.post("/notify", form_data)
+        # We fail because we couldn't retrieve our attachment
+        assert response.status_code == 400
+        assert mock_notify.call_count == 0
+
+        # Reset our mock object
+        mock_notify.reset_mock()
+
         # Preare our json data (and support attach keyword as alias)
         json_data = {
             "body": "test notifiction",
@@ -441,7 +462,7 @@ class StatelessNotifyTests(SimpleTestCase):
         # Reset our mock object
         mock_notify.reset_mock()
 
-        # Preare our json data (and support attachments keyword as plural alias)
+        # Preare our json data (and support attachments keyword as alias)
         json_data = {
             "body": "test notifiction",
             "urls": ", ".join(

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1233,10 +1233,21 @@ class NotifyView(View):
                 # Acquire kw (alias) attach to work with them
                 content["attachment"] = [a for a in request.POST.getlist("attach") if isinstance(a, str) and a.strip()]
 
+            elif "attachments" in request.POST:
+                # Acquire kw (plural alias) attachments to work with them
+                content["attachment"] = [
+                    a for a in request.POST.getlist("attachments") if isinstance(a, str) and a.strip()
+                ]
+
             elif content.get("attach"):
                 # Acquire kw (alias) attach from payload to work with
                 content["attachment"] = content["attach"]
                 del content["attach"]
+
+            elif content.get("attachments"):
+                # Acquire kw (plural alias) attachments from payload to work with
+                content["attachment"] = content["attachments"]
+                del content["attachments"]
 
         if "attachment" in content or request.FILES:
             try:
@@ -2173,10 +2184,19 @@ class StatelessNotifyView(View):
                 # Acquire kw (alias) attach to work with them
                 content["attachment"] = request.POST.getlist("attach")
 
+            elif "attachments" in request.POST:
+                # Acquire kw (plural alias) attachments to work with them
+                content["attachment"] = request.POST.getlist("attachments")
+
             elif content.get("attach"):
                 # Acquire kw (alias) attach from payload to work with
                 content["attachment"] = content["attach"]
                 del content["attach"]
+
+            elif content.get("attachments"):
+                # Acquire kw (plural alias) attachments from payload to work with
+                content["attachment"] = content["attachments"]
+                del content["attachments"]
 
         if "attachment" in content or request.FILES:
             try:

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1240,14 +1240,16 @@ class NotifyView(View):
                 ]
 
             elif content.get("attach"):
-                # Acquire kw (alias) attach from payload to work with
+                # Acquire kw (alias) attach from payload to work with.
+                # Preserve the original alias key as downstream validation
+                # may still inspect the submitted payload structure.
                 content["attachment"] = content["attach"]
-                del content["attach"]
 
             elif content.get("attachments"):
-                # Acquire kw (alias) attachments from payload to work with
+                # Acquire kw (alias) attachments from payload to work with.
+                # Preserve the original alias key as downstream validation
+                # may still inspect the submitted payload structure.
                 content["attachment"] = content["attachments"]
-                del content["attachments"]
 
         if "attachment" in content or request.FILES:
             try:

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1234,7 +1234,7 @@ class NotifyView(View):
                 content["attachment"] = [a for a in request.POST.getlist("attach") if isinstance(a, str) and a.strip()]
 
             elif "attachments" in request.POST:
-                # Acquire kw (plural alias) attachments to work with them
+                # Acquire kw (alias) attachments to work with them
                 content["attachment"] = [
                     a for a in request.POST.getlist("attachments") if isinstance(a, str) and a.strip()
                 ]
@@ -1245,7 +1245,7 @@ class NotifyView(View):
                 del content["attach"]
 
             elif content.get("attachments"):
-                # Acquire kw (plural alias) attachments from payload to work with
+                # Acquire kw (alias) attachments from payload to work with
                 content["attachment"] = content["attachments"]
                 del content["attachments"]
 
@@ -2185,7 +2185,7 @@ class StatelessNotifyView(View):
                 content["attachment"] = request.POST.getlist("attach")
 
             elif "attachments" in request.POST:
-                # Acquire kw (plural alias) attachments to work with them
+                # Acquire kw (alias) attachments to work with them
                 content["attachment"] = request.POST.getlist("attachments")
 
             elif content.get("attach"):
@@ -2194,7 +2194,7 @@ class StatelessNotifyView(View):
                 del content["attach"]
 
             elif content.get("attachments"):
-                # Acquire kw (plural alias) attachments from payload to work with
+                # Acquire kw (alias) attachments from payload to work with
                 content["attachment"] = content["attachments"]
                 del content["attachments"]
 

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1240,16 +1240,14 @@ class NotifyView(View):
                 ]
 
             elif content.get("attach"):
-                # Acquire kw (alias) attach from payload to work with.
-                # Preserve the original alias key as downstream validation
-                # may still inspect the submitted payload structure.
+                # Acquire kw (alias) attach from payload to work with
                 content["attachment"] = content["attach"]
+                del content["attach"]
 
             elif content.get("attachments"):
-                # Acquire kw (alias) attachments from payload to work with.
-                # Preserve the original alias key as downstream validation
-                # may still inspect the submitted payload structure.
+                # Acquire kw (alias) attachments from payload to work with
                 content["attachment"] = content["attachments"]
+                del content["attachments"]
 
         if "attachment" in content or request.FILES:
             try:

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1221,33 +1221,29 @@ class NotifyView(View):
             )
 
         # Handle Attachments
+        # Normalize all three accepted attachment aliases — 'attach',
+        # 'attachment', and 'attachments' — into the canonical 'attachment'
+        # key before calling parse_attachments.  Priority order (highest
+        # first): attach > attachment > attachments.  POST form-data keys are
+        # resolved before JSON body keys of the same name so that multipart
+        # form submissions always take precedence.
         attach = None
-        if not content.get("attachment"):
-            if "attachment" in request.POST:
-                # Acquire attachments to work with them
-                content["attachment"] = [
-                    a for a in request.POST.getlist("attachment") if isinstance(a, str) and a.strip()
-                ]
-
-            elif "attach" in request.POST:
-                # Acquire kw (alias) attach to work with them
-                content["attachment"] = [a for a in request.POST.getlist("attach") if isinstance(a, str) and a.strip()]
-
-            elif "attachments" in request.POST:
-                # Acquire kw (alias) attachments to work with them
-                content["attachment"] = [
-                    a for a in request.POST.getlist("attachments") if isinstance(a, str) and a.strip()
-                ]
-
-            elif content.get("attach"):
-                # Acquire kw (alias) attach from payload to work with
-                content["attachment"] = content["attach"]
-                del content["attach"]
-
-            elif content.get("attachments"):
-                # Acquire kw (alias) attachments from payload to work with
-                content["attachment"] = content["attachments"]
-                del content["attachments"]
+        _post_key = next(
+            (k for k in ("attach", "attachment", "attachments") if k in request.POST),
+            None,
+        )
+        if _post_key:
+            # Collect URL strings from form-data, discarding blank entries.
+            content["attachment"] = [a for a in request.POST.getlist(_post_key) if isinstance(a, str) and a.strip()]
+        else:
+            # Resolve from the JSON body in the same priority order, then
+            # rename the alias to the canonical 'attachment' key.
+            _json_key = next(
+                (k for k in ("attach", "attachment", "attachments") if content.get(k)),
+                None,
+            )
+            if _json_key and _json_key != "attachment":
+                content["attachment"] = content.pop(_json_key)
 
         if "attachment" in content or request.FILES:
             try:
@@ -2007,8 +2003,64 @@ class StatelessNotifyView(View):
         if not content.get("title") and "title" in request.GET:
             content["title"] = request.GET["title"]
 
+        # Handle Attachments
+        # Normalize all three accepted attachment aliases — 'attach',
+        # 'attachment', and 'attachments' — into the canonical 'attachment'
+        # key before calling parse_attachments.  Priority order (highest
+        # first): attach > attachment > attachments.  POST form-data keys are
+        # resolved before JSON body keys of the same name so that multipart
+        # form submissions always take precedence.
+        attach = None
+        _post_key = next(
+            (k for k in ("attach", "attachment", "attachments") if k in request.POST),
+            None,
+        )
+        if _post_key:
+            # Collect URL strings from form-data, discarding blank entries.
+            content["attachment"] = [a for a in request.POST.getlist(_post_key) if isinstance(a, str) and a.strip()]
+        else:
+            # Resolve from the JSON body in the same priority order, then
+            # rename the alias to the canonical 'attachment' key.
+            _json_key = next(
+                (k for k in ("attach", "attachment", "attachments") if content.get(k)),
+                None,
+            )
+            if _json_key and _json_key != "attachment":
+                content["attachment"] = content.pop(_json_key)
+
+        if "attachment" in content or request.FILES:
+            try:
+                attach = parse_attachments(content.get("attachment"), request.FILES)
+
+            except (TypeError, ValueError) as e:
+                # Invalid entry found in list
+                logger.warning(
+                    "NOTIFY - %s - Bad attachment: %s",
+                    request.META["REMOTE_ADDR"],
+                    str(e),
+                )
+
+                status = ResponseCode.bad_request
+                msg = _("Bad Attachment")
+                return (
+                    HttpResponse(msg, status=status, content_type="text/plain")
+                    if not json_response
+                    else JsonResponse(
+                        {
+                            "error": msg,
+                        },
+                        encoder=JSONEncoder,
+                        safe=False,
+                        status=status,
+                    )
+                )
+
         # Some basic error checking
-        if not content.get("body") or content.get("type", apprise.NotifyType.INFO.value) not in apprise.NOTIFY_TYPES:
+        # A notification requires at minimum a body or at least one valid
+        # attachment; either is sufficient to proceed.
+        if (not content.get("body") and not attach) or content.get(
+            "type", apprise.NotifyType.INFO.value
+        ) not in apprise.NOTIFY_TYPES:
             logger.warning(
                 "NOTIFY - %s - Payload lacks minimum requirements",
                 request.META["REMOTE_ADDR"],
@@ -2172,58 +2224,6 @@ class StatelessNotifyView(View):
                     status=status,
                 )
             )
-
-        # Handle Attachments
-        attach = None
-        if not content.get("attachment"):
-            if "attachment" in request.POST:
-                # Acquire attachments to work with them
-                content["attachment"] = request.POST.getlist("attachment")
-
-            elif "attach" in request.POST:
-                # Acquire kw (alias) attach to work with them
-                content["attachment"] = request.POST.getlist("attach")
-
-            elif "attachments" in request.POST:
-                # Acquire kw (alias) attachments to work with them
-                content["attachment"] = request.POST.getlist("attachments")
-
-            elif content.get("attach"):
-                # Acquire kw (alias) attach from payload to work with
-                content["attachment"] = content["attach"]
-                del content["attach"]
-
-            elif content.get("attachments"):
-                # Acquire kw (alias) attachments from payload to work with
-                content["attachment"] = content["attachments"]
-                del content["attachments"]
-
-        if "attachment" in content or request.FILES:
-            try:
-                attach = parse_attachments(content.get("attachment"), request.FILES)
-
-            except (TypeError, ValueError) as e:
-                # Invalid entry found in list
-                logger.warning(
-                    "NOTIFY - %s - Bad attachment: %s",
-                    request.META["REMOTE_ADDR"],
-                    str(e),
-                )
-
-                status = ResponseCode.bad_request
-                msg = _("Bad Attachment")
-                return (
-                    HttpResponse(msg, status=status, content_type="text/plain")
-                    if not json_response
-                    else JsonResponse(
-                        {
-                            "error": msg,
-                        },
-                        encoder=JSONEncoder,
-                        safe=False,
-                        status=status,
-                    )
-                )
 
         # Our return content type can be controlled by the Accept keyword
         # If it includes /* or /html somewhere then we return html, otherwise


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #328 

The Apprise core plugin writes `payload["attachments"]` (plural) in JSON mode, but the receiver only normalizes `attachment` (canonical) and `attach` (the alias from #173). The plural key gets silently dropped: if it's the only carrier, the request 400s with "Payload lacks minimum requirements"; if `body` is also present, the request succeeds with 200 and the attachment is invisibly lost.

This affects any client that follows the documented JSON shape from #208, including Apprise core's own `apprise_api` plugin and `apprise://...?method=json` recursion.

The fix mirrors the `attach` alias pattern from #173 for plural `attachments` in both `NotifyView` and `StatelessNotifyView`, covering multipart-form and JSON-body shapes. Two tests parallel the existing `attach` JSON-body coverage and confirm the alias resolves through to `parse_attachments`.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/63](https://github.com/caronc/apprise-docs/pull/63)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b fix/attachments-plural-alias https://github.com/jamcalli/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
