### PR TITLE
mqtt:// plugin now requires paho-mqtt >= 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "gevent",
   "gunicorn",
   "requests",
-  "paho-mqtt < 2.0.0",
+  "paho-mqtt >= 2.1.0",
   "gntp",
   "cryptography",
   "django-prometheus",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ gunicorn
 requests
 
 ## 3rd Party Service support
-paho-mqtt < 2.0.0
+paho-mqtt >= 2.1.0
 gntp
 cryptography
 # Pretty Good Privacy (PGP) Provides mailto:// and deltachat:// support


### PR DESCRIPTION
## Description
**Related issue (if applicable):** https://github.com/caronc/apprise/pull/1613

The MQTT adaption in Apprise now requires a `paho-mqtt` to be a minimum version of v2.1.0

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/66](https://github.com/caronc/apprise-docs/pull/66)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b mqtt-paho-v2-support https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver -- --branch=802-paho-mqtt-alignment
```
