### PR TITLE
bump slixmpp version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "django-prometheus",
   "PGPy",
   "smpplib",
-  "slixmpp >= 1.10.0",
+  "slixmpp >= 1.16.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ PGPy
 # Provides smpp:// support
 smpplib
 # For xmpp:// support
-slixmpp >= 1.10.0
+slixmpp >= 1.16.0
 
 # prometheus metrics
 django-prometheus


### PR DESCRIPTION
## Description
**Related issue (if applicable):** https://github.com/caronc/apprise/pull/1637

<!--
  -- Have anything else to describe?
  -- Define it here.
-->

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/81](https://github.com/caronc/apprise-docs/pull/81)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b 1637-slixmpp-version-bump https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
