### PR TITLE
?name= support fixed on http:// attachments

### DIFF
--- a/apprise_api/api/tests/test_attachment.py
+++ b/apprise_api/api/tests/test_attachment.py
@@ -632,3 +632,170 @@ class AttachmentTests(SimpleTestCase):
             assert isinstance(result, list)
             assert len(result) == 1
             assert result[0].mimetype == "image/jpeg"
+
+    def test_http_attachment_name_priority(self):
+        """HTTPAttachment name resolution: explicit > ?name= > None (auto)."""
+        with override_settings(APPRISE_ATTACH_DIR=self.tmp_dir.name):
+            # ?name= from URL (no explicit filename): no TypeError, name used
+            a = HTTPAttachment(
+                host="example.com",
+                fullpath="/thumbnails/6dba.jpg",
+                secure=True,
+                name="thumbnail.jpg",
+            )
+            assert a._name == "thumbnail.jpg"
+            assert a.filename == "thumbnail.jpg"
+
+            # Explicit filename beats URL's ?name=
+            a = HTTPAttachment(
+                "explicit.jpg",
+                host="example.com",
+                fullpath="/thumbnails/6dba.jpg",
+                secure=True,
+                name="url_name.jpg",
+            )
+            assert a._name == "explicit.jpg"
+            assert a.filename == "explicit.jpg"
+
+            # No filename, no ?name= -> auto-detect during download
+            a = HTTPAttachment(
+                host="example.com",
+                fullpath="/thumbnails/6dba.jpg",
+                secure=True,
+            )
+            assert a._name is None
+            assert a.filename is None
+
+    @patch("requests.get")
+    def test_url_attachment_name_resolution(self, mock_get):
+        """parse_attachments derives attachment name from URL intelligently."""
+        response = mock.Mock()
+        response.status_code = requests.codes.ok
+        response.raise_for_status.return_value = True
+        response.headers = {}
+        response.iter_content.return_value = iter([b"data"])
+        response.__enter__ = lambda s, *a, **kw: response
+        response.__exit__ = mock.Mock(return_value=False)
+        mock_get.return_value = response
+
+        # ?name= in URL: name is taken from query param (no TypeError)
+        result = parse_attachments(
+            ["https://example.com/thumbnails/6dba.jpg?name=thumbnail.jpg"],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "thumbnail.jpg"
+
+        # URL has a filename in path, no ?name=: _name stays None so
+        # AttachHTTP.download() can discover the basename naturally
+        result = parse_attachments(
+            ["https://example.com/thumbnails/6dba96988a83163dcffe0d75e4a28bc5.jpg"],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name is None
+
+        # URL has no path filename: fallback to attachment.NNN
+        result = parse_attachments(["https://example.com/"], {})
+        assert len(result) == 1
+        assert result[0]._name == "attachment.001"
+
+        # ?name= is empty: treated as not specified; name from URL path
+        result = parse_attachments(
+            ["https://example.com/thumbnails/6dba.jpg?name="],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name is None
+
+        # ?name= is whitespace only (%20 is a URL-encoded space): same as empty
+        result = parse_attachments(
+            ["https://example.com/thumbnails/6dba.jpg?name=%20%20%20"],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name is None
+
+        # ?name= has path traversal: only basename is kept
+        result = parse_attachments(
+            ["https://example.com/thumbnails/6dba.jpg?name=/etc/passwd"],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "passwd"
+
+        # ?name= has relative path traversal: only basename is kept
+        result = parse_attachments(
+            ["https://example.com/thumbnails/6dba.jpg?name=../../secret.jpg"],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "secret.jpg"
+
+        # ?name= empty with no path filename: still falls back to NNN
+        result = parse_attachments(
+            ["https://example.com/?name="],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "attachment.001"
+
+    @patch("requests.get")
+    def test_dict_url_attachment_name_resolution(self, mock_get):
+        """parse_attachments dict+url form: filename priority order."""
+        response = mock.Mock()
+        response.status_code = requests.codes.ok
+        response.raise_for_status.return_value = True
+        response.headers = {}
+        response.iter_content.return_value = iter([b"data"])
+        response.__enter__ = lambda s, *a, **kw: response
+        response.__exit__ = mock.Mock(return_value=False)
+        mock_get.return_value = response
+
+        # Dict filename overrides URL ?name= (explicit user choice wins)
+        result = parse_attachments(
+            [{"url": "https://example.com/img.jpg?name=url_name.jpg", "filename": "custom.jpg"}],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "custom.jpg"
+
+        # No dict filename + URL ?name=: URL name used (no TypeError)
+        result = parse_attachments(
+            [{"url": "https://example.com/img.jpg?name=thumbnail.jpg"}],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "thumbnail.jpg"
+
+        # No dict filename, no ?name=, path has filename: auto-detect
+        result = parse_attachments(
+            [{"url": "https://example.com/thumbnails/photo.jpg"}],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name is None
+
+        # No dict filename, no ?name=, no path filename: attachment.NNN
+        result = parse_attachments(
+            [{"url": "https://example.com/"}],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "attachment.001"
+
+        # URL ?name= empty: treated as not specified; path basename used
+        result = parse_attachments(
+            [{"url": "https://example.com/thumbnails/photo.jpg?name="}],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name is None
+
+        # URL ?name= path traversal: only basename kept
+        result = parse_attachments(
+            [{"url": "https://example.com/img.jpg?name=/etc/passwd"}],
+            {},
+        )
+        assert len(result) == 1
+        assert result[0]._name == "passwd"

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -173,11 +173,18 @@ class HTTPAttachment(A_MGR["http"]):
     Web Attachments
     """
 
-    def __init__(self, filename, delete=True, **kwargs):
+    def __init__(self, filename=None, delete=True, **kwargs):
         """
         Initialize our attachment
         """
-        self._filename = filename
+        # Pop any name that parse_url() extracted from a ?name= query
+        # parameter.  We must remove it from kwargs before passing to
+        # AttachBase to avoid "multiple values for keyword argument 'name'".
+        # Priority: explicit filename arg > URL ?name= > None (auto-detect).
+        url_name = kwargs.pop("name", None)
+        effective_name = filename if filename is not None else url_name
+
+        self._filename = effective_name
         self.delete = delete
         self._path = None
         try:
@@ -194,11 +201,11 @@ class HTTPAttachment(A_MGR["http"]):
 
         except FileNotFoundError:
             raise ValueError(
-                "Could not prepare {} attachment in {}".format(filename, settings.APPRISE_ATTACH_DIR)
+                "Could not prepare {} attachment in {}".format(effective_name, settings.APPRISE_ATTACH_DIR)
             ) from None
 
         # Prepare our item
-        super().__init__(name=filename, **kwargs)
+        super().__init__(name=effective_name, **kwargs)
 
         # Update our file size based on the settings value
         self.max_file_size = settings.APPRISE_ATTACH_SIZE
@@ -345,7 +352,27 @@ def parse_attachments(attachment_payload, files_request):
                     # We are not allowed to use this entry
                     raise ValueError(f"Denied attachment {no} (blocked web request): {entry}")
 
-                attachment = HTTPAttachment(filename, **A_MGR["http"].parse_url(entry))
+                _parsed = A_MGR["http"].parse_url(entry)
+                # Sanitize any URL-derived ?name=: strip directory components
+                # (?name=/etc/passwd → "passwd") and treat an empty or
+                # whitespace-only result as not specified so the fallback
+                # chain below still applies.
+                if "name" in _parsed:
+                    _sanitized = os.path.basename(_parsed["name"]).strip()
+                    if _sanitized:
+                        _parsed["name"] = _sanitized
+                    else:
+                        del _parsed["name"]
+
+                # ?name= wins when present; otherwise derive from the URL path
+                # basename so .../6dba.jpg doesn't get renamed to attachment.001.
+                # Only fall back to attachment.NNN when no name can be found.
+                if "name" not in _parsed:
+                    _path_name = os.path.basename(_parsed.get("fullpath", "").rstrip("/"))
+                    if not _path_name:
+                        _parsed["name"] = filename
+
+                attachment = HTTPAttachment(**_parsed)
                 if not attachment:
                     # We failed to retrieve the attachment
                     raise ValueError(f"Failed to retrieve attachment {no}: {entry}")
@@ -366,10 +393,28 @@ def parse_attachments(attachment_payload, files_request):
                                     f"Denied attachment {no} (blocked web request): {entry[AttachmentPayload.URL]}"
                                 )
 
-                            attachment = HTTPAttachment(
-                                filename,
-                                **A_MGR["http"].parse_url(entry[AttachmentPayload.URL]),
-                            )
+                            _parsed = A_MGR["http"].parse_url(entry[AttachmentPayload.URL])
+                            # Sanitize any URL-derived ?name= (same rules
+                            # as the string-URL path above).
+                            if "name" in _parsed:
+                                _sanitized = os.path.basename(_parsed["name"]).strip()
+                                if _sanitized:
+                                    _parsed["name"] = _sanitized
+                                else:
+                                    del _parsed["name"]
+
+                            # User-provided dict filename overrides all URL
+                            # derived names.  If absent, prefer URL ?name=
+                            # then path basename, then attachment.NNN.
+                            _dict_filename = entry.get("filename", "").strip()
+                            if _dict_filename:
+                                _parsed["name"] = _dict_filename
+                            elif "name" not in _parsed:
+                                _path_name = os.path.basename(_parsed.get("fullpath", "").rstrip("/"))
+                                if not _path_name:
+                                    _parsed["name"] = filename
+
+                            attachment = HTTPAttachment(**_parsed)
                             if not attachment:
                                 # We failed to retrieve the attachment
                                 raise ValueError(f"Failed to retrieve attachment {no}: {entry}")


### PR DESCRIPTION
## Description
**Related issue (if applicable):** https://github.com/caronc/apprise/pull/1645

This pairs with the Apprise PR above to correctly support `?name=` in Attachments provided in addition to properly parsing the filename from the URL if possible before falling back to the filename `attachment.001` if not detected.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/84](https://github.com/caronc/apprise-docs/pull/84)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b attachment-handling-fix https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000 (tests against branch it pairs with)
tox -e runserver -- --branch=attachment-http-name-fix
```
