### PR TITLE
feat: allow parsing stringified json fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,10 @@ curl -X POST \
     "http://localhost:8000/notify/{KEY}?:event::json.title=title&:event::json.state=type"
 ```
 
-The double-colon modifier can be placed anywhere in the path where a string value needs to be parsed (e.g. `items::json[0].title` or `items[0]::json.title`). It can also be used for flat field mapping (e.g. `?:event::json=body`) to parse the JSON string and map the resulting dict/list to the target Apprise field.
+The double-colon modifier can be placed anywhere in the path where a string value needs to be parsed (e.g. `items::json[0].title` or `items[0]::json.title`).
+
+> [!IMPORTANT]
+> Mapped Apprise fields that expect scalar values (`body`, `title`, `type`, and `format`) cannot be assigned a raw parsed dictionary or list (e.g. `?:event::json=body` will fail validation). Ensure the mapping rule traverses down to a scalar value (e.g. `?:event::json.title=title`).
 
 ## Metrics Collection & Analysis
 

--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,28 @@ curl -g -X POST \
     -d '{"items":[{"title":"New post","objectURI":"https://example.com/q/1234"}]}' \
     "http://localhost:8000/notify/{KEY}?:items[0].title=title&:items[0].objectURI=body"
 ```
+
+### Parsing Stringified JSON Fields
+
+If a field in your third-party payload contains a stringified JSON string, you can instruct the engine to parse it as JSON by adding the `::json` modifier to that segment name in your mapping rules. This allows you to walk into it using dot-notation/bracket-notation or map the parsed object directly.
+
+For example, if a tool sends a form POST or JSON containing a stringified JSON string:
+
+```bash
+# Payload sent by the third-party tool:
+# {
+#   "event": "{\"title\": \"CPU spike\", \"state\": \"critical\"}"
+# }
+#
+# Parse the "event" string as JSON and map its subfields:
+curl -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"event":"{\"title\":\"CPU spike\",\"state\":\"critical\"}"}' \
+    "http://localhost:8000/notify/{KEY}?:event::json.title=title&:event::json.state=type"
+```
+
+The double-colon modifier can be placed anywhere in the path where a string value needs to be parsed (e.g. `items::json[0].title` or `items[0]::json.title`). It can also be used for flat field mapping (e.g. `?:event::json=body`) to parse the JSON string and map the resulting dict/list to the target Apprise field.
+
 ## Metrics Collection & Analysis
 
 Basic Prometheus support added through `/metrics` reference point.

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -318,4 +318,20 @@ def remap_fields(rules, payload, form=None):
             # assignment
             payload[key] = value
 
+    # ------------------------------------------------------------------
+    # Validate final payload values for expected scalar fields.
+    # Expected fields format, type, title, and body must be scalar values.
+    # ------------------------------------------------------------------
+    scalar_fields = {"format", "type", "title", "body"}
+    for field in scalar_fields:
+        if field in payload:
+            val = payload[field]
+            if isinstance(val, dict | list):
+                logger.warning(
+                    "Payload mapping error: Field '%s' was assigned a dictionary or list value, "
+                    "which is not a valid scalar.",
+                    field,
+                )
+                return False
+
     return True

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -39,20 +39,20 @@ def _parse_path(key):
     """
     Parse a mapping key into a flat, ordered list of traversal steps.
 
-    Each step is a ``('key', name)`` or ``('index', N)`` tuple:
+    Each step is a ``('key', name, parse_json)`` or ``('index', N, parse_json)`` tuple:
 
-    * ``('key', name)``  - perform a dict lookup for *name*.
-    * ``('index', N)``   - dereference integer index *N* of the current list.
+    * ``('key', name, parse_json)``   - perform a dict lookup for *name*.
+    * ``('index', N, parse_json)``    - dereference integer index *N* of the current list.
 
     Supported forms::
 
-        "title"                 → [('key', 'title')]
-        "event.title"           → [('key', 'event'), ('key', 'title')]
-        "items[0]"              → [('key', 'items'), ('index', 0)]
-        "items[0].objectURI"    → [('key', 'items'), ('index', 0),
-                                    ('key', 'objectURI')]
-        "a[0][2][2].b[3]"       → [('key', 'a'), ('index', 0), ('index', 2),
-                                    ('index', 2), ('key', 'b'), ('index', 3)]
+        "title"                 → [('key', 'title', False)]
+        "event.title"           → [('key', 'event', False), ('key', 'title', False)]
+        "items[0]"              → [('key', 'items', False), ('index', 0, False)]
+        "items[0].objectURI"    → [('key', 'items', False), ('index', 0, False),
+                                    ('key', 'objectURI', False)]
+        "a[0][2][2].b[3]"       → [('key', 'a', False), ('index', 0, False), ('index', 2, False),
+                                    ('index', 2, False), ('key', 'b', False), ('index', 3, False)]
 
     Returns ``(steps, None)`` on success.  Returns ``(None, reason)`` when
     the key contains malformed bracket notation — any of:
@@ -67,36 +67,65 @@ def _parse_path(key):
         if not segment:
             return None, f"empty segment in path '{key}'"
 
-        if "[" not in segment and "]" not in segment:
-            # Plain dict key — no bracket characters at all
-            steps.append(("key", segment))
+        if "::json" in segment:
+            parts = segment.split("::json", 1)
+            left, right = parts[0], parts[1]
+        else:
+            left, right = segment, ""
+
+        segment_steps = []
+
+        # Helper to parse a part of a segment (like left or right)
+        def parse_part(part, parse_json_on_last, steps_out):
+            if not part:
+                return True
+
+            if "[" not in part and "]" not in part:
+                # Plain dict key — no bracket characters at all
+                steps_out.append(("key", part, parse_json_on_last))
+                return True
+
+            # At least one bracket character is present.
+            # A stray ']' before any '[' is immediately malformed.
+            bracket_pos = part.find("[")
+            if bracket_pos == -1:
+                return False
+
+            key_name = part[:bracket_pos]
+            remaining = part[bracket_pos:]
+
+            # A ']' appearing before the first '[' is malformed (e.g. 'a]b[0]').
+            if "]" in key_name:
+                return False
+
+            part_steps = []
+            if key_name:
+                part_steps.append(("key", key_name))
+
+            # Consume every [N] subscript greedily; any leftover chars are malformed.
+            while remaining:
+                m = _SUBSCRIPT_RE.match(remaining)
+                if not m:
+                    return False
+                part_steps.append(("index", int(m.group(1))))
+                remaining = remaining[m.end() :]
+
+            for i, step in enumerate(part_steps):
+                is_last = i == len(part_steps) - 1
+                steps_out.append((step[0], step[1], parse_json_on_last if is_last else False))
+
+            return True
+
+        if not parse_part(left, "::json" in segment, segment_steps):
+            return None, f"malformed segment '{segment}'"
+
+        if not parse_part(right, False, segment_steps):
+            return None, f"malformed segment '{segment}'"
+
+        if not segment_steps:
             continue
 
-        # At least one bracket character is present.
-        # A stray ']' before any '[' is immediately malformed.
-        bracket_pos = segment.find("[")
-        if bracket_pos == -1:
-            return None, (f"malformed bracket notation at '{segment}' (unexpected ']' with no matching '[')")
-
-        key_name = segment[:bracket_pos]
-        remaining = segment[bracket_pos:]
-
-        # A ']' appearing before the first '[' is malformed (e.g. 'a]b[0]').
-        if "]" in key_name:
-            return None, (f"malformed bracket notation at '{segment}'; unexpected ']' before '['")
-
-        if key_name:
-            steps.append(("key", key_name))
-
-        # Consume every [N] subscript greedily; any leftover chars are malformed.
-        while remaining:
-            m = _SUBSCRIPT_RE.match(remaining)
-            if not m:
-                return None, (
-                    f"malformed bracket notation at '{segment}'; expected [N] where N is a non-negative integer"
-                )
-            steps.append(("index", int(m.group(1))))
-            remaining = remaining[m.end() :]
+        steps.extend(segment_steps)
 
     return steps, None
 
@@ -106,14 +135,14 @@ def _get_nested(payload, steps, source_key):
     Traverse *payload* using the pre-parsed *steps* produced by
     :func:`_parse_path`.
 
-    Each step is a ``('key', name)`` or ``('index', N)`` tuple.
+    Each step is a ``(step_type, step_val, parse_json)`` tuple.
 
     Returns ``(value, True)`` on success.  Logs a WARNING and returns
     ``(None, False)`` when traversal cannot be completed (missing key,
     not-indexable node, or out-of-range index).
     """
     current = payload
-    for step_type, step_val in steps:
+    for step_type, step_val, parse_json in steps:
         if step_type == "key":
             if not isinstance(current, dict) or step_val not in current:
                 logger.warning(
@@ -143,6 +172,14 @@ def _get_nested(payload, steps, source_key):
                     len(current),
                 )
                 return None, False
+
+        if parse_json and isinstance(current, str):
+            try:
+                import json
+
+                current = json.loads(current)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
 
     return current, True
 
@@ -205,7 +242,7 @@ def remap_fields(rules, payload, form=None):
         # that stray/unmatched brackets are caught and rejected as malformed
         # rather than silently falling through to flat-field handling.
         # ------------------------------------------------------------------
-        if "." in key or "[" in key or "]" in key:
+        if "." in key or "[" in key or "]" in key or "::json" in key:
             steps, err = _parse_path(key)
             if steps is None:
                 logger.warning(

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -247,14 +247,9 @@ def remap_fields(rules, payload, form=None):
                 continue
 
             if value in expected_keys:
-                if key not in expected_keys or value not in payload:
-                    payload[value] = payload[key]
-                    del payload[key]
-                else:
-                    _tmp = payload[value]
-                    payload[value] = payload[key]
-                    payload[key] = _tmp
-            elif key in expected_keys or key in payload:
+                payload[value] = payload[key]
+                del payload[key]
+            else:
                 payload[key] = value
             continue
 

--- a/apprise_api/api/payload_mapper.py
+++ b/apprise_api/api/payload_mapper.py
@@ -68,7 +68,7 @@ def _parse_path(key):
             return None, f"empty segment in path '{key}'"
 
         if "::json" in segment:
-            parts = segment.split("::json", 1)
+            parts = segment.rsplit("::json", 1)
             left, right = parts[0], parts[1]
         else:
             left, right = segment, ""
@@ -236,6 +236,28 @@ def remap_fields(rules, payload, form=None):
     # First generate our expected keys; only these can be mapped
     expected_keys = set(form.fields.keys())
     for key, value in rules.items():
+        # ------------------------------------------------------------------
+        # If the key contains "::json" but exists literally in the payload,
+        # we treat it as a flat field mapping to preserve backward
+        # compatibility for literal key names containing "::json".
+        # ------------------------------------------------------------------
+        if "::json" in key and key in payload:
+            if not value:
+                del payload[key]
+                continue
+
+            if value in expected_keys:
+                if key not in expected_keys or value not in payload:
+                    payload[value] = payload[key]
+                    del payload[key]
+                else:
+                    _tmp = payload[value]
+                    payload[value] = payload[key]
+                    payload[key] = _tmp
+            elif key in expected_keys or key in payload:
+                payload[key] = value
+            continue
+
         # ------------------------------------------------------------------
         # Dot-notation and/or array-index path handling.
         # Any bracket character (either '[' or ']') triggers this branch so

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -1669,16 +1669,25 @@ class NotifyTests(SimpleTestCase):
         response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
         assert response.status_code == 200
 
-        # Subfield mapping via form POST — expected to fail (400).
+        # Subfield mapping via form POST — expected to fail (400) by default.
         # Form POST delivers flat string values; the "event" key arrives as a
         # plain string, not a nested dict, so the dot-notation path cannot be
-        # resolved.
+        # resolved without explicit JSON parsing.
         response = self.client.post(
             f"/notify/{key}/?:event.title=title&:event.body=body",
             {"event": '{"title": "hi", "body": "world"}'},
         )
         assert response.status_code == 400
         assert mock_notify.call_count == 0
+
+        # Subfield mapping via form POST with explicit ::json modifier — succeeds (200)
+        # because the modifier triggers parsing of the string into a dictionary.
+        response = self.client.post(
+            f"/notify/{key}/?:event::json.title=title&:event::json.body=body",
+            {"event": '{"title": "hi", "body": "world"}'},
+        )
+        assert response.status_code == 200
+        assert mock_notify.call_count == 1
 
         mock_notify.reset_mock()
 

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -377,13 +377,16 @@ class NotifyPayloadMapper(SimpleTestCase):
         assert payload["body"] == "nested value"
 
         #
-        # Flat field mapping with explicit ::json modifier
+        # Flat field mapping with explicit ::json modifier - fails because target
+        # field 'body' is a scalar field and cannot receive a dictionary.
         #
         rules = {"event::json": "body"}
         payload = {"event": '{"title": "hi"}'}
 
-        assert remap_fields(rules, payload) is True
-        assert payload["body"] == {"title": "hi"}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "assigned a dictionary or list value" in "\n".join(cm.output)
 
         #
         # Invalid JSON string with modifier — fails gracefully (warning logged)
@@ -423,6 +426,16 @@ class NotifyPayloadMapper(SimpleTestCase):
 
         assert remap_fields(rules, payload) is True
         assert payload["title"] == "nested value"
+
+        #
+        # Mapping dict/list to scalar fields (body/title/etc.) fails validation
+        #
+        rules = {"event::json": "body"}
+        payload = {"event": '{"nested": "value"}'}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "assigned a dictionary or list value" in "\n".join(cm.output)
 
     def test_remap_fields_array_index(self):
         """

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -335,6 +335,77 @@ class NotifyPayloadMapper(SimpleTestCase):
         assert remap_fields(rules, payload) is True
         assert "nonexistent_apprise_field" not in payload
 
+        #
+        # Without ::json modifier, subfield mapping on a string event fails (returns False, warning logged)
+        #
+        rules = {"event.title": "title"}
+        payload = {"event": '{"title": "hi"}'}
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+        assert result is False
+        assert "event.title" in "\n".join(cm.output)
+
+        #
+        # Subfield mapping with explicit ::json modifier
+        #
+        rules = {
+            "event::json.title": "title",
+            "event::json.body": "body",
+        }
+        payload = {"event": '{"title": "hi", "body": "world"}'}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["title"] == "hi"
+        assert payload["body"] == "world"
+
+        #
+        # List index mapping with explicit ::json modifier (modifier on list key)
+        #
+        rules = {"items::json[0].value": "body"}
+        payload = {"items": '[{"value": "nested value"}]'}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "nested value"
+
+        #
+        # List index mapping with explicit ::json modifier (modifier on list element)
+        #
+        rules = {"items[0]::json.value": "body"}
+        payload = {"items": ['{"value": "nested value"}']}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "nested value"
+
+        #
+        # Flat field mapping with explicit ::json modifier
+        #
+        rules = {"event::json": "body"}
+        payload = {"event": '{"title": "hi"}'}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == {"title": "hi"}
+
+        #
+        # Invalid JSON string with modifier — fails gracefully (warning logged)
+        #
+        rules = {"event::json.title": "title"}
+        payload = {"event": "{invalid json}"}
+
+        with self.assertLogs("django", level="WARNING") as cm:
+            result = remap_fields(rules, payload)
+
+        assert result is False
+        assert "event::json.title" in "\n".join(cm.output)
+
+        #
+        # Double-nested stringified JSON parsing
+        #
+        rules = {"event::json.info::json.title": "title"}
+        payload = {"event": '{"info": "{\\"title\\": \\"nested CPU spike\\"}"}'}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["title"] == "nested CPU spike"
+
     def test_remap_fields_array_index(self):
         """
         Test bracket/array-index notation in remap_fields:
@@ -494,39 +565,56 @@ class NotifyPayloadMapper(SimpleTestCase):
         # Plain key
         steps, err = _parse_path("title")
         assert err is None
-        assert steps == [("key", "title")]
+        assert steps == [("key", "title", False)]
 
         # Dot-notation
         steps, err = _parse_path("a.b.c")
         assert err is None
-        assert steps == [("key", "a"), ("key", "b"), ("key", "c")]
+        assert steps == [("key", "a", False), ("key", "b", False), ("key", "c", False)]
 
         # Single subscript
         steps, err = _parse_path("items[0]")
         assert err is None
-        assert steps == [("key", "items"), ("index", 0)]
+        assert steps == [("key", "items", False), ("index", 0, False)]
 
         # Subscript + subfield
         steps, err = _parse_path("items[0].objectURI")
         assert err is None
-        assert steps == [("key", "items"), ("index", 0), ("key", "objectURI")]
+        assert steps == [("key", "items", False), ("index", 0, False), ("key", "objectURI", False)]
 
         # Chained subscripts
         steps, err = _parse_path("a[0][2][2]")
         assert err is None
-        assert steps == [("key", "a"), ("index", 0), ("index", 2), ("index", 2)]
+        assert steps == [("key", "a", False), ("index", 0, False), ("index", 2, False), ("index", 2, False)]
 
         # Full complex path
         steps, err = _parse_path("key[0][2][2].value[3]")
         assert err is None
         assert steps == [
-            ("key", "key"),
-            ("index", 0),
-            ("index", 2),
-            ("index", 2),
-            ("key", "value"),
-            ("index", 3),
+            ("key", "key", False),
+            ("index", 0, False),
+            ("index", 2, False),
+            ("index", 2, False),
+            ("key", "value", False),
+            ("index", 3, False),
         ]
+
+        # Explicit JSON modifiers
+        steps, err = _parse_path("event::json.title")
+        assert err is None
+        assert steps == [("key", "event", True), ("key", "title", False)]
+
+        steps, err = _parse_path("items[0]::json.value")
+        assert err is None
+        assert steps == [("key", "items", False), ("index", 0, True), ("key", "value", False)]
+
+        steps, err = _parse_path("items::json[0].value")
+        assert err is None
+        assert steps == [("key", "items", True), ("index", 0, False), ("key", "value", False)]
+
+        steps, err = _parse_path("a[0]::json[1]")
+        assert err is None
+        assert steps == [("key", "a", False), ("index", 0, True), ("index", 1, False)]
 
         # Malformed: missing closing bracket
         steps, err = _parse_path("items[0")
@@ -563,7 +651,7 @@ class NotifyPayloadMapper(SimpleTestCase):
         # equivalent to "items[0]".
         steps, err = _parse_path("items.[0]")
         assert err is None
-        assert steps == [("key", "items"), ("index", 0)]
+        assert steps == [("key", "items", False), ("index", 0, False)]
 
     def test_get_nested(self):
         """

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -406,6 +406,24 @@ class NotifyPayloadMapper(SimpleTestCase):
         assert remap_fields(rules, payload) is True
         assert payload["title"] == "nested CPU spike"
 
+        #
+        # Literal key containing "::json" — bypassed and mapped literally
+        #
+        rules = {"event::json": "body"}
+        payload = {"event::json": "literal value"}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["body"] == "literal value"
+
+        #
+        # Literal key containing "::json" whose value is stringified JSON — parsed using double modifier
+        #
+        rules = {"event::json::json.title": "title"}
+        payload = {"event::json": '{"title": "nested value"}'}
+
+        assert remap_fields(rules, payload) is True
+        assert payload["title"] == "nested value"
+
     def test_remap_fields_array_index(self):
         """
         Test bracket/array-index notation in remap_fields:

--- a/apprise_api/api/tests/test_payload_mapper.py
+++ b/apprise_api/api/tests/test_payload_mapper.py
@@ -427,7 +427,6 @@ class NotifyPayloadMapper(SimpleTestCase):
         assert remap_fields(rules, payload) is True
         assert payload["title"] == "nested value"
 
-        #
         # Mapping dict/list to scalar fields (body/title/etc.) fails validation
         #
         rules = {"event::json": "body"}
@@ -436,6 +435,22 @@ class NotifyPayloadMapper(SimpleTestCase):
             result = remap_fields(rules, payload)
         assert result is False
         assert "assigned a dictionary or list value" in "\n".join(cm.output)
+
+        #
+        # Literal key containing "::json" — deleted
+        #
+        rules = {"event::json": ""}
+        payload = {"event::json": "literal value"}
+        assert remap_fields(rules, payload) is True
+        assert "event::json" not in payload
+
+        #
+        # Literal key containing "::json" — assigned to non-expected value
+        #
+        rules = {"event::json": "non_expected_value"}
+        payload = {"event::json": "literal value"}
+        assert remap_fields(rules, payload) is True
+        assert payload["event::json"] == "non_expected_value"
 
     def test_remap_fields_array_index(self):
         """
@@ -683,6 +698,16 @@ class NotifyPayloadMapper(SimpleTestCase):
         steps, err = _parse_path("items.[0]")
         assert err is None
         assert steps == [("key", "items", False), ("index", 0, False)]
+
+        # Malformed: modifier followed by invalid subscript
+        steps, err = _parse_path("event::json[abc]")
+        assert steps is None
+        assert "malformed" in err
+
+        # Modifier-only segment continues without adding steps
+        steps, err = _parse_path("a.::json.b")
+        assert err is None
+        assert steps == [("key", "a", False), ("key", "b", False)]
 
     def test_get_nested(self):
         """


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #<!-- apprise-api issue number goes here -->
This PR adds support for an explicit double-colon `::json` modifier inside third-party webhook payload mapping rules. 
If a third-party webhook sends a payload containing stringified JSON, you can add `::json` to that segment name in your mapping rules to instruct the engine to parse the string in-place. This allows you to traverse into the parsed JSON structure using standard dot-notation and bracket-notation, or map the parsed object directly.

### Features
- **Nested & Chained parsing**: Walk into deeply nested JSON string fields (e.g., `event::json.info::json.title`).
- **List element parsing**: Works seamlessly with bracket/index notation on lists (e.g., `items::json[0].value` or `items[0]::json.value`).
- **Flat field parsing**: Parse and map stringified JSON directly (e.g. `?:event::json=body`).
- **Literal Match Priority**: If a payload key literally contains the `::json` string, it is matched directly without traversal/parsing, ensuring 100% backward compatibility.
- **Scalar Type Validation**: Enforces that mapped scalar fields (`format`, `type`, `title`, and `body`) cannot be assigned a `dict` or `list` object. If a type mismatch occurs, it fails validation gracefully (logs a warning and returns HTTP 400) to prevent runtime crashes in downstream notification plugins.
 
## Checklist
* [ ] Documentation ticket created (if applicable): N/A (updated README.md directly in this PR)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`). (some preexisting html lints exist unrelated to these changes)
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b <this.branch-name> https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```

Successful Parsing & Mapping: Send a POST request with a nested stringified JSON payload using the ::json modifier in mapping rules:

```bash
curl -X POST \
  -H "Content-Type: application/json" \
  -d '{"event": "{\"title\": \"CPU spike\", \"state\": \"critical\"}"}' \
  "http://localhost:8000/notify/{KEY}?:event::json.title=title&:event::json.state=type"
```

Verification error case trying to map json to apprise fields

```bash
curl -i -X POST \
  -H "Content-Type: application/json" \
  -d '{"event": "{\"title\": \"CPU spike\"}"}' \
  "http://localhost:8000/notify/{KEY}?:event::json=body"
...
HTTP/1.1 400 Bad Request
Date: Sat, 04 Jul 2026 00:41:31 GMT
Server: WSGIServer/0.2 CPython/3.14.6
Content-Type: application/json
Content-Length: 41

{"error": "Payload field mapping failed"}
```