### PR TITLE
leverage Apprise v2 improved callback log handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Some people may wish to only have a sidecar solution that does require use of an
 
 | Path         | Method | Description |
 |------------- | ------ | ----------- |
-| `/notify/` |  POST  | Sends one or more notifications to the URLs identified as part of the payload, or those identified in the environment variable `APPRISE_STATELESS_URLS`. <br/>*Payload Parameters*<br/>📌 **urls**: One or more URLs identifying where the notification should be sent to. If this field isn't specified then it automatically assumes the `settings.APPRISE_STATELESS_URLS` value or `APPRISE_STATELESS_URLS` environment variable.<br/>📌 **body**: Your message body. This is a required field.<br/>📌 **title**: Optionally define a title to go along with the *body*.<br/>📌 **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `failure`. If no *type* is specified then `info` is the default value used.<br/>📌 **format**: Optionally identify the text format of the data you're feeding Apprise. The valid options are `text`, `markdown`, `html`. If nothing is specified, no format is applied and the content is passed through untouched.
+| `/notify/` |  POST  | Sends one or more notifications to the URLs identified as part of the payload, or those identified in the environment variable `APPRISE_STATELESS_URLS`. <br/>*Payload Parameters*<br/>📌 **urls**: One or more URLs identifying where the notification should be sent to. If this field isn't specified then it automatically assumes the `settings.APPRISE_STATELESS_URLS` value or `APPRISE_STATELESS_URLS` environment variable.<br/>📌 **body**: Your message body. This is a required field.<br/>📌 **title**: Optionally define a title to go along with the *body*.<br/>📌 **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `failure`. If no *type* is specified then `info` is the default value used.<br/>📌 **format**: Optionally identify the text format of the data you're feeding Apprise. The valid options are `text`, `markdown`, `html`. If nothing is specified, no format is applied and the content is passed through untouched.<br/>📌 Add `?stream=yes` (or `Accept: text/event-stream`) for progress while notification work is still running — see [Live Progress Streaming](#live-progress-streaming) below.
 
 Stateless `/notify` calls do not require `/config`, but they do leverage `/attach` for file uploads (assuming `APPRISE_ATTACH_SIZE` is not set to `0` (zero).  You can optionally use `/plugin` if you have custom Apprise plugins you wish to use.
 
@@ -357,7 +357,7 @@ You can pre-save all of your Apprise configuration and/or set of Apprise URLs an
 | `/del/{KEY}` |  POST  | Removes Apprise Configuration from the persistent store. This path does not work if `APPRISE_CONFIG_LOCK` is set.
 | `/cfg/{KEY}` |  POST  | Returns the Apprise Configuration from the persistent store.  This can be directly used with the *Apprise CLI* and/or the *AppriseConfig()* object ([see here for details](https://appriseit.com/config/)). This path does not work if `APPRISE_CONFIG_LOCK` is set. This is an alias of `/get/{KEY}` (identified next).
 | `/get/{KEY}` |  POST  | Returns the Apprise Configuration from the persistent store.  This can be directly used with the *Apprise CLI* and/or the *AppriseConfig()* object ([see here for details](https://appriseit.com/config/)). This path does not work if `APPRISE_CONFIG_LOCK` is set. This is also provided via `/cfg/{KEY}` as an alias.
-| `/notify/{KEY}` |  POST  | Sends notification(s) to all of the end points you've previously configured associated with a *{KEY}*.<br/>*Payload Parameters*<br/>📌 **body**: Your message body. This is the *only* required field.<br/>📌 **title**: Optionally define a title to go along with the *body*.<br/>📌 **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `failure`. If no *type* is specified then `info` is the default value used.<br/>📌 **tag**: Optionally notify only those tagged accordingly. Use a comma (`,`) to `OR` your tags and a space (` `) to `AND` them. More details on this can be seen documented below.<br/>📌 **format**: Optionally identify the text format of the data you're feeding Apprise. The valid options are `text`, `markdown`, `html`. If nothing is specified, no format is applied and the content is passed through untouched.
+| `/notify/{KEY}` |  POST  | Sends notification(s) to all of the end points you've previously configured associated with a *{KEY}*.<br/>*Payload Parameters*<br/>📌 **body**: Your message body. This is the *only* required field.<br/>📌 **title**: Optionally define a title to go along with the *body*.<br/>📌 **type**: Defines the message type you want to send as.  The valid options are `info`, `success`, `warning`, and `failure`. If no *type* is specified then `info` is the default value used.<br/>📌 **tag**: Optionally notify only those tagged accordingly. Use a comma (`,`) to `OR` your tags and a space (` `) to `AND` them. More details on this can be seen documented below.<br/>📌 **format**: Optionally identify the text format of the data you're feeding Apprise. The valid options are `text`, `markdown`, `html`. If nothing is specified, no format is applied and the content is passed through untouched.<br/>📌 Add `?stream=yes` (or `Accept: text/event-stream`) for progress while notification work is still running — see [Live Progress Streaming](#live-progress-streaming) below.
 | `/json/urls/{KEY}` |  GET  | Returns a JSON response object that contains all of the URLS and Tags associated with the key specified.
 | `/details` |  GET  | Set the `Accept` Header to `application/json` and retrieve a JSON response object that contains all of the supported Apprise URLs. See [here for more details](https://appriseit.com/dev/apprise_details/)
 | `/metrics` |  GET  | Prometheus endpoint for _basic_ Metrics Collection & Analysis and/or Observability.
@@ -471,6 +471,35 @@ curl -X POST -d '{"tag":"leaders teamA, leaders teamB", "body":"meeting now"}' \
     -H "Content-Type: application/json" \
     http://localhost:8000/notify/projectX
 ```
+
+### Live Progress Streaming
+
+Both notification endpoints can stream progress as each service is notified. Use `?stream=yes` or send `Accept: text/event-stream`.
+
+Normal responses still wait for notification work to finish, but send retained
+logs one entry at a time. This avoids rebuilding a large result in memory. Live
+progress streaming sends logs while notification work is still running.
+
+The response contains `log` events followed by one `result` event. An unexpected processing failure produces an `error` event instead. See the `StreamEvent` schema in `swagger.yaml` for the event fields.
+
+Slow clients keep up to 2 MB in memory before using automatically cleaned temporary storage, which holds up to 256 MB by default. During normal operation, events remain ordered and are not omitted while the client stays connected.
+
+If the storage limit is reached or temporary storage fails, notification delivery continues and the stream reports an `ERROR` log asking the caller to contact the server administrator. Later logs continue whenever space becomes available.
+
+```bash
+curl -N -X POST -d '{"tag":"devops", "body":"repo outage"}' \
+    -H "Content-Type: application/json" \
+    "http://localhost:8000/notify/abc123?stream=yes"
+```
+
+```text
+event: log
+data: {"level": "INFO", "asctime": "2025-01-01 12:00:00,000", "message": "Sent to Telegram", "service": "Telegram"}
+
+event: result
+data: {"status": "SUCCESS"}
+```
+
 ### API Response Codes
 
 |  HTTP Code | Name                  | Effect                         |
@@ -516,6 +545,8 @@ The use of environment variables allow you to provide overrides to default setti
 | `APPRISE_ATTACH_SIZE` | Over-ride the attachment size (defined in MB). By default it is set to `200` (Megabytes). You can set this up to a maximum value of `500` which is the restriction in place for NginX (internal hosting ervice) at this time.  If you set this to zero (`0`) then attachments will not be passed along even if provided.
 | `APPRISE_UPLOAD_MAX_MEMORY_SIZE` | Over-ride the in-memory accepted payload size (defined in MB). By default it is set to `3` (Megabytes). There is no reason the HTTP payload (excluding attachments) should exceed this limit.  This value is only configurable for those who have edge cases where there are exceptions to this rule.
 | `APPRISE_CONFIG_MAX_LENGTH` | Over-ride the maximum accepted configuration payload length (defined in KB). The value provided (in KB) is internally converted to bytes and can never exceed `APPRISE_UPLOAD_MAX_MEMORY_SIZE` (defined in MB). The default is `512` (KB).
+| `APPRISE_STREAM_MEMORY_SIZE` | Memory used by each live stream before waiting logs move to disk, in MB. The same value limits memory used by completed result logs. The default is `2`. Set it to `0` to use disk immediately when disk storage is enabled.
+| `APPRISE_STREAM_DISK_SIZE` | Temporary disk allowance for each live stream and, separately, each completed result, in MB. The default is `256`. Set it to `0` to disable temporary disk storage and keep result logs in memory. Live streams also remain in memory when the memory size is greater than `0`; when both sizes are `0`, live-stream backlog retention is disabled.
 | `APPRISE_STATELESS_URLS` | For a non-persistent solution, you can take advantage of this global variable. Use this to define a default set of Apprise URLs to notify when using API calls to `/notify`.  If no `{KEY}` is defined when calling `/notify` then the URLs defined here are used instead. By default, nothing is defined for this variable.
 | `APPRISE_STATEFUL_MODE` | This can be set to the following possible modes:<br/>📌 **hash**: This is also the default.  It stores the server configuration in a hash formatted that can be easily indexed and compressed.<br/>📌 **simple**: Configuration is written straight to disk using the `{KEY}.cfg` (if `TEXT` based) and `{KEY}.yml` (if `YAML` based).<br/>📌 **disabled**: Straight up deny any read/write queries to the servers stateful store.  Effectively turn off the Apprise Stateful feature completely.
 | `APPRISE_CONFIG_LOCK` | Locks down your API hosting so that you can no longer delete/update/access stateful information. Your configuration is still referenced when stateful calls are made to `/notify`.  The idea of this switch is to allow someone to set their (Apprise) configuration up and then as an added security tactic, they may choose to lock their configuration down (in a read-only state). Those who use the Apprise CLI tool may still do it, however the `--config` (`-c`) switch will not successfully reference this access point anymore. You can however use the `apprise://` plugin without any problem ([see here for more details](https://appriseit.com/services/apprise_api/)). This defaults to `no` and can however be set to `yes` by simply defining the global variable as such.

--- a/apprise_api/api/tests/helpers.py
+++ b/apprise_api/api/tests/helpers.py
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2026 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import apprise
+
+
+def notify_result(success=True):
+    """Build a minimal notification result for mocked Apprise calls."""
+    status = apprise.AppriseResultStatus.SUCCESS if success else apprise.AppriseResultStatus.FAILURE
+    return apprise.AppriseResult(status=status, results=[])

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -32,6 +32,7 @@ import requests
 
 from ..forms import NotifyForm
 from ..views import parse_tag_expression
+from .helpers import notify_result
 
 # Grant access to our Notification Manager Singleton
 N_MGR = apprise.manager_plugins.NotificationManager()
@@ -64,7 +65,7 @@ class NotifyTests(SimpleTestCase):
         """
         Stateful notify should pass advanced tag expressions through to Apprise.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
         key = "test_notify_accepts_advanced_tag_expression"
 
         response = self.client.post(
@@ -94,7 +95,7 @@ class NotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # our key to use
         key = "test_notify_by_loaded_urls"
@@ -858,22 +859,17 @@ class NotifyTests(SimpleTestCase):
         # We'll trigger on 2 entries
         assert mock_post.call_count == 2
 
-        # Test our posted data
-        response = json.loads(mock_post.call_args_list[0][1]["data"])
-        headers = mock_post.call_args_list[0][1]["headers"]
-        assert response["title"] == ""
-        assert response["message"] == form_data["body"]
-        assert response["type"] == apprise.NotifyType.INFO.value
-        # Verify we matched the first entry only
-        assert headers["url"] == "2"
-
-        response = json.loads(mock_post.call_args_list[1][1]["data"])
-        headers = mock_post.call_args_list[1][1]["headers"]
-        assert response["title"] == ""
-        assert response["message"] == form_data["body"]
-        assert response["type"] == apprise.NotifyType.INFO.value
-        # Verify we matched the first entry only
-        assert headers["url"] == "3"
+        # Concurrent notifications may finish in either order.
+        matched_urls = set()
+        for call in mock_post.call_args_list:
+            response = json.loads(call[1]["data"])
+            headers = call[1]["headers"]
+            assert response["title"] == ""
+            assert response["message"] == form_data["body"]
+            assert response["type"] == apprise.NotifyType.INFO.value
+            matched_urls.add(headers["url"])
+        # Verify we matched the second and third entries only
+        assert matched_urls == {"2", "3"}
 
         # Reset our object
         mock_post.reset_mock()
@@ -1057,7 +1053,7 @@ class NotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # our key to use
         key = "test_notify_by_loaded_urls_with_json"
@@ -1527,7 +1523,7 @@ class NotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # our key to use
         key = "test_stateful_notify_recursion"
@@ -1615,7 +1611,7 @@ class NotifyTests(SimpleTestCase):
         with stateless notifications.
         """
 
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         key = "test_notify_rule_mapping_preserves_source_case"
 
@@ -1668,7 +1664,7 @@ class NotifyTests(SimpleTestCase):
         every branch in the level-to-int conversion chain, covering the final
         'elif level == "TRACE"' False branch.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         key = "test_notify_invalid_default_log_level"
 
@@ -1700,7 +1696,7 @@ class NotifyTests(SimpleTestCase):
           - emit a WARNING
           - return 400 (not attempt to send the notification)
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         key = "test_notify_subfield_mapping"
 
@@ -1753,3 +1749,75 @@ class NotifyTests(SimpleTestCase):
         )
         assert response.status_code == 200
         assert mock_notify.call_count == 1
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_emits_log_and_result_events(self, mock_notify):
+        """Stateful notifications can stream progress and results live."""
+        fake_service = type("FakeService", (), {"service_name": "JSON"})()
+
+        def fake_notify(*args, **kwargs):
+            log_callback = kwargs["log_callback"]
+            log_callback(
+                apprise.NotifyLogEntry(level="INFO", message="Sent JSON POST notification."),
+                fake_service,
+            )
+            return notify_result(True)
+
+        mock_notify.side_effect = fake_notify
+
+        key = "test_notify_stream_emits_log_and_result_events"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/notify/{}".format(key),
+            {"body": "hello"},
+            HTTP_ACCEPT="text/event-stream",
+        )
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/event-stream"
+
+        body = b"".join(response.streaming_content).decode("utf-8")
+        assert "event: log" in body
+        assert "Sent JSON POST notification." in body
+        assert '"service": "JSON"' in body
+        # Keep sensitive notification targets out of the stream.
+        assert "yahoo.ca" not in body
+        assert "event: result" in body
+        assert '"status": "SUCCESS"' in body
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_via_query_string(self, mock_notify):
+        """The stream query parameter works without an Accept header."""
+        mock_notify.return_value = notify_result(True)
+
+        key = "test_notify_stream_via_query_string_fallback"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        response = self.client.post("/notify/{}?stream=1".format(key), {"body": "hello"})
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/event-stream"
+
+        body = b"".join(response.streaming_content).decode("utf-8")
+        assert "event: result" in body
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_reports_error(self, mock_notify):
+        """Notification exceptions end the stream with an error event."""
+        mock_notify.side_effect = ValueError("boom")
+
+        key = "test_notify_stream_reports_an_unexpected_notify_failure"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/notify/{}".format(key),
+            {"body": "hello"},
+            HTTP_ACCEPT="text/event-stream",
+        )
+        assert response.status_code == 200
+
+        body = b"".join(response.streaming_content).decode("utf-8")
+        assert "event: error" in body
+        assert "boom" in body

--- a/apprise_api/api/tests/test_notify.py
+++ b/apprise_api/api/tests/test_notify.py
@@ -21,7 +21,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 from inspect import cleandoc
+import io
 import json
+import logging
+import queue
+import threading
 from unittest import mock
 
 import apprise
@@ -31,7 +35,18 @@ from django.test import SimpleTestCase, override_settings
 import requests
 
 from ..forms import NotifyForm
-from ..views import parse_tag_expression
+from ..views import (
+    _EVENT_SIZE,
+    _STREAM_PUT_FAILED,
+    _STREAM_PUT_SPOOLED,
+    _safe_stream_log,
+    _SpooledEventQueue,
+    parse_tag_expression,
+    render_notify_logs,
+    render_notify_response,
+    stream_notify_response,
+    stream_result_response,
+)
 from .helpers import notify_result
 
 # Grant access to our Notification Manager Singleton
@@ -43,7 +58,131 @@ class NotifyTests(SimpleTestCase):
     Test notifications
     """
 
-    def test_parse_advanced_tag_expression_preserves_boolean_logic(self):
+    def test_result_rendering_stays_lazy(self):
+        """JSON rendering reads entries only as response chunks are consumed."""
+        consumed = []
+
+        def entries():
+            """Record when the renderer asks for the one available entry."""
+            consumed.append(True)
+            yield apprise.NotifyLogEntry(level="INFO", message="ready")
+
+        chunks = render_notify_logs(
+            entries(),
+            json_response=True,
+            content_type="application/json",
+        )
+
+        # The opening bracket is available before the first log is decoded.
+        assert next(chunks) == "["
+        assert consumed == []
+
+        output = "[" + "".join(chunks)
+        assert json.loads(output)[0][2] == "ready"
+        assert consumed == [True]
+
+    def test_result_rendering_supports_html_and_plain_text(self):
+        """Bounded rendering preserves HTML escaping and text separators."""
+        first = apprise.NotifyLogEntry(level="INFO", message="<ready>")
+        second = apprise.NotifyLogEntry(level="WARNING", message="later")
+
+        html = "".join(
+            render_notify_logs(
+                iter((first,)),
+                json_response=False,
+                content_type="text/html",
+            )
+        )
+        assert html.startswith('<ul class="logs">')
+        assert "&lt;ready&gt;" in html
+        assert html.endswith("</ul>")
+
+        text = "".join(
+            render_notify_logs(
+                iter((first, second)),
+                json_response=False,
+                content_type="text/plain",
+            )
+        )
+        assert text == "{}\n{}".format(first, second)
+
+        # A failed plain-text response still explains an empty log result.
+        fallback = "".join(
+            render_notify_response(
+                iter(()),
+                json_response=False,
+                content_type="text/plain",
+                error="delivery failed",
+            )
+        )
+        assert fallback == "delivery failed"
+
+    def test_result_response_closes_owned_storage(self):
+        """Closing a standard streamed response also closes its result."""
+        result = notify_result(True)
+        result.close = mock.Mock(wraps=result.close)
+
+        response = stream_result_response(
+            result,
+            json_response=True,
+            content_type="application/json",
+            status=200,
+        )
+
+        payload = json.loads(b"".join(response.streaming_content).decode("utf-8"))
+        assert payload == {"error": None, "details": []}
+        result.close.assert_called_once_with()
+
+    @override_settings(APPRISE_STREAM_MEMORY_SIZE=17, APPRISE_STREAM_DISK_SIZE=29)
+    def test_stream_sizes_are_passed_to_notify_assets(self):
+        """Both notification endpoints apply stream limits to result logs."""
+        captured = {}
+        real_asset = apprise.AppriseAsset
+
+        class SpyAsset(real_asset):
+            """Capture asset arguments while preserving normal behavior."""
+
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                super().__init__(**kwargs)
+
+        payload = {
+            "urls": "json://user:pass@localhost",
+            "title": "Test",
+            "body": "Body",
+        }
+        key = "test_stream_sizes_are_passed_to_notify_assets"
+        # Save one stateful configuration before exercising that endpoint.
+        self.client.post(
+            "/add/{}".format(key),
+            {"urls": payload["urls"]},
+        )
+
+        with (
+            mock.patch("apprise.AppriseAsset", SpyAsset),
+            mock.patch("apprise.Apprise.notify", return_value=notify_result(True)),
+        ):
+            self.client.post("/notify/{}".format(key), {"body": "Body"})
+
+        assert captured["result_log_memory_size"] == 17
+        assert captured["result_log_disk_size"] == 29
+        # Clear the first endpoint's values before checking stateless notify.
+        captured.clear()
+
+        with (
+            mock.patch("apprise.AppriseAsset", SpyAsset),
+            mock.patch("apprise.Apprise.notify", return_value=notify_result(True)),
+        ):
+            self.client.post(
+                "/notify",
+                data=json.dumps(payload),
+                content_type="application/json",
+            )
+
+        assert captured["result_log_memory_size"] == 17
+        assert captured["result_log_disk_size"] == 29
+
+    def test_tag_expression_preserves_logic(self):
         """
         Advanced tag tokens should not change existing OR/AND behavior.
         """
@@ -59,6 +198,450 @@ class NotifyTests(SimpleTestCase):
         ]
         with self.assertRaises(ValueError):
             parse_tag_expression("family:")
+
+    def test_stream_queue_preserves_spooled_order(self):
+        """Slow-reader overflow moves to disk and keeps every event."""
+        events = _SpooledEventQueue(memory_bytes=6, disk_bytes=1024)
+
+        # Six bytes hold the first two events; later events must use disk.
+        assert events.put("one") is None
+        assert events.put("two") is None
+        assert events.put("three") == _STREAM_PUT_SPOOLED
+        assert events.put("four") is None
+        assert events.qsize() == 4
+
+        # Reading crosses the memory/disk boundary without changing order.
+        assert [events.get() for _ in range(4)] == [
+            "one",
+            "two",
+            "three",
+            "four",
+        ]
+        assert events.close() == (0, 4, 2, 0)
+        assert events.put("closed") is None
+        with self.assertRaises(queue.Empty):
+            events.get()
+
+        large_event = _SpooledEventQueue(memory_bytes=3, disk_bytes=1024)
+        # One event larger than memory goes directly to disk.
+        assert large_event.put("four") == _STREAM_PUT_SPOOLED
+        assert large_event.get() == "four"
+        large_event.close()
+
+    @override_settings(APPRISE_STREAM_MEMORY_SIZE=3, APPRISE_STREAM_DISK_SIZE=1024)
+    def test_stream_queue_uses_django_size_settings(self):
+        """The queue reads its default limits from Django settings."""
+        events = _SpooledEventQueue()
+
+        assert events.put("one") is None
+        assert events.put("two") == _STREAM_PUT_SPOOLED
+        assert events.get() == "one"
+        assert events.get() == "two"
+        events.close()
+
+    def test_stream_queue_reuses_disk_after_drain(self):
+        """A full disk spool drops overflow but can be reused after draining."""
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=11)
+
+        assert events.put("one") == _STREAM_PUT_SPOOLED
+        with self.assertLogs("django", level="WARNING"):
+            assert events.put("two") == _STREAM_PUT_FAILED
+        # Repeated overflow stays contained without repeating the warning.
+        assert events.put("two") == _STREAM_PUT_FAILED
+        assert events.get() == "one"
+
+        # Draining closes the full file, allowing a fresh spool to be used.
+        assert events.put("two") is None
+        assert events.get() == "two"
+        assert events.close() == (0, 1, 2, 2)
+
+    def test_stream_queue_zero_size_modes(self):
+        """Zero selects memory-only, disk-only, or no-buffer operation."""
+        memory_only = _SpooledEventQueue(memory_bytes=1, disk_bytes=0)
+        # A zero disk limit keeps the earlier unbounded-memory behavior.
+        assert memory_only.put("one") is None
+        assert memory_only.put("two") is None
+        assert memory_only.get() == "one"
+        assert memory_only.get() == "two"
+        assert memory_only.close() == (0, 2, 0, 0)
+
+        disk_only = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        # A zero memory limit sends the first event straight to disk.
+        assert disk_only.put("one") == _STREAM_PUT_SPOOLED
+        assert disk_only.get() == "one"
+        disk_only.close()
+
+        disabled = _SpooledEventQueue(memory_bytes=0, disk_bytes=0)
+        # With both limits zero, the event is counted but not retained.
+        with self.assertLogs("django", level="WARNING"):
+            assert disabled.put("one") == _STREAM_PUT_FAILED
+        assert disabled.storage_failed() is True
+        assert disabled.close() == (0, 0, 0, 1)
+
+    def test_stream_queue_recovers_from_create_failure(self):
+        """A disk failure drops no in-memory data and allows later logging."""
+        events = _SpooledEventQueue(memory_bytes=5, disk_bytes=1024)
+        assert events.put("one") is None
+
+        with (
+            mock.patch("api.views.tempfile.TemporaryFile", side_effect=OSError("disk full")),
+            self.assertLogs("django", level="ERROR"),
+        ):
+            assert events.put("two") == _STREAM_PUT_FAILED
+
+        assert events.storage_failed() is True
+        # Full memory remains bounded after disk storage becomes unavailable.
+        assert events.put("also unavailable") is None
+        assert events.get() == "one"
+        # Once memory drains, best-effort in-memory delivery resumes.
+        assert events.put("three") is None
+        assert events.get() == "three"
+        assert events.close() == (0, 1, 0, 2)
+
+    def test_stream_queue_preserves_events_on_write_failure(self):
+        """A partial write does not damage events already on disk."""
+
+        class FailingSpool(io.BytesIO):
+            """Fail the second event written to this temporary file."""
+
+            def __init__(self):
+                super().__init__()
+                self.write_count = 0
+
+            def write(self, value):
+                self.write_count += 1
+                if self.write_count == 2:
+                    super().write(value[:1])
+                    raise OSError("disk full")
+                return super().write(value)
+
+        spool = FailingSpool()
+        events = _SpooledEventQueue(memory_bytes=3, disk_bytes=1024)
+        with mock.patch("api.views.tempfile.TemporaryFile", return_value=spool):
+            events.put("one")
+            assert events.put("two") == _STREAM_PUT_SPOOLED
+            with self.assertLogs("django", level="ERROR"):
+                assert events.put("three") == _STREAM_PUT_FAILED
+
+        assert events.get() == "one"
+        assert events.get() == "two"
+        assert events.close() == (0, 2, 1, 1)
+
+    def test_stream_queue_contains_write_and_close_failures(self):
+        """Short writes and close errors are contained and reported."""
+
+        class ShortWriteSpool(io.BytesIO):
+            """Accept only part of the event and then fail cleanup."""
+
+            close_failed = False
+
+            def write(self, value):
+                super().write(value[:-1])
+                return len(value) - 1
+
+            def close(self):
+                if not self.close_failed:
+                    self.close_failed = True
+                    raise OSError("close failed")
+                super().close()
+
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        with (
+            mock.patch("api.views.tempfile.TemporaryFile", return_value=ShortWriteSpool()),
+            self.assertLogs("django", level="ERROR"),
+        ):
+            assert events.put("one") == _STREAM_PUT_FAILED
+
+        assert events.storage_failed() is True
+        assert events.close() == (0, 0, 0, 1)
+
+    def test_stream_queue_ignores_truncate_failure(self):
+        """A failed partial-write cleanup does not hide the original error."""
+
+        class FailingTruncateSpool(io.BytesIO):
+            """Keep one disk event, then fail its next write and truncate."""
+
+            def __init__(self):
+                super().__init__()
+                self.write_count = 0
+
+            def write(self, value):
+                self.write_count += 1
+                if self.write_count == 2:
+                    raise OSError("write failed")
+                return super().write(value)
+
+            def truncate(self, *args, **kwargs):
+                raise OSError("truncate failed")
+
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        spool = FailingTruncateSpool()
+        with mock.patch("api.views.tempfile.TemporaryFile", return_value=spool):
+            assert events.put("one") == _STREAM_PUT_SPOOLED
+            with self.assertLogs("django", level="ERROR"):
+                assert events.put("two") == _STREAM_PUT_FAILED
+
+        assert events.get() == "one"
+        events.close()
+
+    def test_stream_queue_contains_unreadable_disk_data(self):
+        """Unreadable temporary data becomes an alertable storage failure."""
+        spool = io.BytesIO()
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        with mock.patch("api.views.tempfile.TemporaryFile", return_value=spool):
+            assert events.put("one") == _STREAM_PUT_SPOOLED
+
+        spool.seek(0)
+        # Remove nearly all of the length header before reading it back.
+        spool.truncate(1)
+        with (
+            self.assertLogs("django", level="ERROR"),
+            self.assertRaises(queue.Empty),
+        ):
+            events.get()
+
+        assert events.storage_failed() is True
+        assert events.close() == (0, 1, 1, 1)
+
+        short_payload = io.BytesIO()
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        with mock.patch("api.views.tempfile.TemporaryFile", return_value=short_payload):
+            events.put("payload")
+        short_payload.seek(0)
+        # Keep a full header but only one byte of its declared payload.
+        short_payload.truncate(_EVENT_SIZE.size + 1)
+        with (
+            self.assertLogs("django", level="ERROR"),
+            self.assertRaises(queue.Empty),
+        ):
+            events.get()
+        events.close()
+
+    def test_stream_reports_storage_failure_and_completes(self):
+        """Disk failure alerts the client without stopping notification work."""
+        fake_service = type("FakeService", (), {"service_name": "JSON"})()
+        notify_finished = mock.Mock()
+
+        class FakeApprise:
+            """Emit enough entries to require temporary storage."""
+
+            def notify(self, *args, **kwargs):
+                kwargs["log_callback"](
+                    apprise.NotifyLogEntry(level="INFO", message="one"),
+                    fake_service,
+                )
+                kwargs["log_callback"](
+                    apprise.NotifyLogEntry(level="INFO", message="two"),
+                    fake_service,
+                )
+                notify_finished()
+                return notify_result(True)
+
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        with (
+            mock.patch.dict(
+                stream_notify_response.__globals__,
+                {"_SpooledEventQueue": mock.Mock(return_value=events)},
+            ),
+            mock.patch("api.views.tempfile.TemporaryFile", side_effect=OSError("disk full")),
+        ):
+            response = stream_notify_response(
+                FakeApprise(),
+                body="test",
+                title="",
+                notify_type=apprise.NotifyType.INFO,
+                tag=None,
+                attach=None,
+                log_level=logging.INFO,
+            )
+            body = b"".join(response.streaming_content).decode("utf-8")
+
+        notify_finished.assert_called_once_with()
+        assert "event: result" in body
+        assert "notification processing is continuing" in body
+        assert "Please contact the server administrator" in body
+
+    def test_stream_contains_logging_failure(self):
+        """A broken server log handler cannot stop notification work."""
+        with mock.patch.object(
+            _safe_stream_log.__globals__["logger"],
+            "log",
+            side_effect=RuntimeError("handler failed"),
+        ):
+            _safe_stream_log(logging.ERROR, "test")
+            events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+            with mock.patch(
+                "api.views.tempfile.TemporaryFile",
+                side_effect=OSError("disk full"),
+            ):
+                assert events.put("one") == _STREAM_PUT_FAILED
+
+        assert events.storage_failed() is True
+        assert events.close() == (0, 0, 0, 1)
+
+    def test_stream_queue_contains_cleanup_failure(self):
+        """A cleanup failure is reported after the saved event is read."""
+
+        class CloseFailSpool(io.BytesIO):
+            """Store events normally but fail when closed."""
+
+            close_failed = False
+
+            def close(self):
+                if not self.close_failed:
+                    self.close_failed = True
+                    raise ValueError("close failed")
+                super().close()
+
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        with mock.patch("api.views.tempfile.TemporaryFile", return_value=CloseFailSpool()):
+            assert events.put("one") == _STREAM_PUT_SPOOLED
+            with self.assertLogs("django", level="ERROR"):
+                assert events.get() == "one"
+
+        assert events.storage_failed() is True
+        assert events.close() == (0, 1, 1, 0)
+
+    def test_stream_spools_and_reports_backlog(self):
+        """A normal disk-backed stream reports its slow-reader statistics."""
+        fake_service = type("FakeService", (), {"service_name": "JSON"})()
+
+        class FakeApprise:
+            """Emit one entry and finish successfully."""
+
+            def notify(self, *args, **kwargs):
+                kwargs["log_callback"](
+                    apprise.NotifyLogEntry(level="INFO", message="one"),
+                    fake_service,
+                )
+                return notify_result(True)
+
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        with (
+            mock.patch.dict(
+                stream_notify_response.__globals__,
+                {"_SpooledEventQueue": mock.Mock(return_value=events)},
+            ),
+            self.assertLogs("django", level="INFO") as logs,
+        ):
+            response = stream_notify_response(
+                FakeApprise(),
+                body="test",
+                title="",
+                notify_type=apprise.NotifyType.INFO,
+                tag=None,
+                attach=None,
+                log_level=logging.INFO,
+            )
+            body = b"".join(response.streaming_content).decode("utf-8")
+
+        assert "event: log" in body
+        assert "event: result" in body
+        assert any("backlog moved" in message for message in logs.output)
+        assert any("spooled 1 event" in message for message in logs.output)
+
+    def test_stream_handles_worker_start_failure(self):
+        """A worker startup failure returns a safe error event."""
+        with (
+            mock.patch.object(threading.Thread, "start", side_effect=RuntimeError("no threads")),
+            self.assertLogs("django", level="ERROR") as logs,
+        ):
+            response = stream_notify_response(
+                mock.Mock(),
+                body="test",
+                title="",
+                notify_type=apprise.NotifyType.INFO,
+                tag=None,
+                attach=None,
+                log_level=logging.INFO,
+            )
+            body = b"".join(response.streaming_content).decode("utf-8")
+
+        assert "event: error" in body
+        assert "Notification processing failed" in body
+        assert any("could not start" in message for message in logs.output)
+
+    def test_stream_disconnect_does_not_stop_notification(self):
+        """Client disconnect cleanup leaves notification work running."""
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        class FakeApprise:
+            """Wait for the test while simulating active notification work."""
+
+            def notify(self, *args, **kwargs):
+                kwargs["log_callback"](
+                    apprise.NotifyLogEntry(level="INFO", message="pending"),
+                    None,
+                )
+                started.set()
+                release.wait(2)
+                finished.set()
+                return notify_result(True)
+
+        response = stream_notify_response(
+            FakeApprise(),
+            body="test",
+            title="",
+            notify_type=apprise.NotifyType.INFO,
+            tag=None,
+            attach=None,
+            log_level=logging.INFO,
+        )
+        iterator = iter(response.streaming_content)
+        assert next(iterator) == b": connected\n\n"
+        assert started.wait(1)
+
+        with self.assertLogs("django", level="WARNING") as logs:
+            response.close()
+
+        release.set()
+        assert finished.wait(1)
+        assert any("before notification processing finished" in message for message in logs.output)
+        assert any("pending event" in message for message in logs.output)
+
+    def test_stream_handles_disk_read_failure(self):
+        """A disk read failure alerts the client and still returns a result."""
+
+        class ReadFailSpool(io.BytesIO):
+            """Accept the event but fail when the stream reads it back."""
+
+            def read(self, *args, **kwargs):
+                raise OSError("read failed")
+
+        class FakeApprise:
+            """Emit one entry and finish successfully."""
+
+            def notify(self, *args, **kwargs):
+                kwargs["log_callback"](
+                    apprise.NotifyLogEntry(level="INFO", message="one"),
+                    None,
+                )
+                return notify_result(True)
+
+        events = _SpooledEventQueue(memory_bytes=0, disk_bytes=1024)
+        with (
+            mock.patch.dict(
+                stream_notify_response.__globals__,
+                {"_SpooledEventQueue": mock.Mock(return_value=events)},
+            ),
+            mock.patch("api.views.tempfile.TemporaryFile", return_value=ReadFailSpool()),
+            self.assertLogs("django", level="ERROR"),
+        ):
+            response = stream_notify_response(
+                FakeApprise(),
+                body="test",
+                title="",
+                notify_type=apprise.NotifyType.INFO,
+                tag=None,
+                attach=None,
+                log_level=logging.INFO,
+            )
+            body = b"".join(response.streaming_content).decode("utf-8")
+
+        assert "event: result" in body
+        assert "server storage limit or error" in body
 
     @mock.patch("apprise.Apprise.notify")
     def test_notify_accepts_advanced_tag_expression(self, mock_notify):
@@ -885,22 +1468,17 @@ class NotifyTests(SimpleTestCase):
         # We'll trigger on 2 entries
         assert mock_post.call_count == 2
 
-        # Test our posted data
-        response = json.loads(mock_post.call_args_list[0][1]["data"])
-        headers = mock_post.call_args_list[0][1]["headers"]
-        assert response["title"] == ""
-        assert response["message"] == form_data["body"]
-        assert response["type"] == apprise.NotifyType.INFO.value
-        # Verify we matched the first entry only
-        assert headers["url"] == "1"
-
-        response = json.loads(mock_post.call_args_list[1][1]["data"])
-        headers = mock_post.call_args_list[1][1]["headers"]
-        assert response["title"] == ""
-        assert response["message"] == form_data["body"]
-        assert response["type"] == apprise.NotifyType.INFO.value
-        # Verify we matched the first entry only
-        assert headers["url"] == "3"
+        # Concurrent notifications may finish in either order.
+        matched_urls = set()
+        for call in mock_post.call_args_list:
+            response = json.loads(call[1]["data"])
+            headers = call[1]["headers"]
+            assert response["title"] == ""
+            assert response["message"] == form_data["body"]
+            assert response["type"] == apprise.NotifyType.INFO.value
+            matched_urls.add(headers["url"])
+        # Verify we matched the first and third entries only.
+        assert matched_urls == {"1", "3"}
 
         # Reset our object
         mock_post.reset_mock()
@@ -1236,10 +1814,7 @@ class NotifyTests(SimpleTestCase):
         # Reset our mock object
         mock_notify.reset_mock()
 
-        # Test every alias alone (no body) via JSON to confirm attach-only
-        # payloads are accepted and resolve to Bad Attachment, not the
-        # minimum-requirements gate.  Also exercises the 'attachment' canonical
-        # key path directly, which skips alias renaming.
+        # Every alias works without a body and reaches attachment validation.
         for _alias in ("attach", "attachment", "attachments"):
             json_data = {
                 _alias: "https://localhost/invalid/path/to/image.png",
@@ -1605,11 +2180,8 @@ class NotifyTests(SimpleTestCase):
         assert mock_notify.call_count == 0
 
     @mock.patch("apprise.Apprise.notify")
-    def test_notify_by_loaded_urls_rule_mapping_preserves_source_case(self, mock_notify):
-        """
-        Test that rule-based field remapping preserves source key case
-        with stateless notifications.
-        """
+    def test_stateful_notify_preserves_mapping_case(self, mock_notify):
+        """Rule-based field mapping preserves source key case."""
 
         mock_notify.return_value = notify_result(True)
 
@@ -1689,12 +2261,9 @@ class NotifyTests(SimpleTestCase):
 
     @mock.patch("apprise.Apprise.notify")
     def test_notify_subfield_mapping(self, mock_notify):
-        """
-        Test dot-notation subfield mapping rules at the HTTP layer (stateful).
+        """Test stateful nested-field mapping.
 
-        A missing subfield path must:
-          - emit a WARNING
-          - return 400 (not attempt to send the notification)
+        Missing paths warn and return 400 without sending.
         """
         mock_notify.return_value = notify_result(True)
 
@@ -1703,10 +2272,7 @@ class NotifyTests(SimpleTestCase):
         response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
         assert response.status_code == 200
 
-        # Subfield mapping via form POST — expected to fail (400).
-        # Form POST delivers flat string values; the "event" key arrives as a
-        # plain string, not a nested dict, so the dot-notation path cannot be
-        # resolved.
+        # Form posts are flat strings, so nested paths cannot be resolved.
         response = self.client.post(
             f"/notify/{key}/?:event.title=title&:event.body=body",
             {"event": '{"title": "hi", "body": "world"}'},
@@ -1751,7 +2317,7 @@ class NotifyTests(SimpleTestCase):
         assert mock_notify.call_count == 1
 
     @mock.patch("apprise.Apprise.notify")
-    def test_notify_stream_emits_log_and_result_events(self, mock_notify):
+    def test_notify_streams_logs_and_result(self, mock_notify):
         """Stateful notifications can stream progress and results live."""
         fake_service = type("FakeService", (), {"service_name": "JSON"})()
 
@@ -1786,6 +2352,87 @@ class NotifyTests(SimpleTestCase):
         assert "event: result" in body
         assert '"status": "SUCCESS"' in body
 
+    @mock.patch("api.views.send_webhook")
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_sends_webhook(self, mock_notify, mock_webhook):
+        """Stateful streams send their completion webhook."""
+        mock_notify.return_value = notify_result(True)
+        payload = {}
+
+        # Consume the bounded webhook while its result storage is still open.
+        mock_webhook.side_effect = lambda chunks: payload.update(json.loads("".join(chunks)))
+
+        key = "test_notify_stream_sends_webhook"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        with override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"):
+            response = self.client.post(
+                "/notify/{}".format(key),
+                {"body": "hello"},
+                HTTP_ACCEPT="text/event-stream",
+            )
+            b"".join(response.streaming_content)
+
+        mock_webhook.assert_called_once()
+        assert payload["status"] == 0
+        assert isinstance(payload["output"], list)
+
+    @mock.patch("api.views.send_webhook", side_effect=RuntimeError("boom"))
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_contains_webhook_error(self, mock_notify, mock_webhook):
+        """A broken completion webhook does not change the stream result."""
+        mock_notify.return_value = notify_result(True)
+        key = "test_notify_stream_contains_webhook_error"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        with (
+            override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"),
+            self.assertLogs("django", level="ERROR"),
+        ):
+            response = self.client.post(
+                "/notify/{}".format(key),
+                {"body": "hello"},
+                HTTP_ACCEPT="text/event-stream",
+            )
+            body = b"".join(response.streaming_content).decode("utf-8")
+
+        mock_webhook.assert_called_once()
+        assert "event: result" in body
+        assert '"status": "SUCCESS"' in body
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_skips_gzip(self, mock_notify):
+        """Stateful event streams remain uncompressed for live delivery."""
+        fake_service = type("FakeService", (), {"service_name": "JSON"})()
+
+        def fake_notify(*args, **kwargs):
+            kwargs["log_callback"](
+                apprise.NotifyLogEntry(level="INFO", message="Sent JSON POST notification."),
+                fake_service,
+            )
+            return notify_result(True)
+
+        mock_notify.side_effect = fake_notify
+
+        key = "test_notify_stream_skips_gzip"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/notify/{}?stream=yes".format(key),
+            {"body": "hello"},
+            HTTP_ACCEPT_ENCODING="gzip, deflate",
+        )
+        assert response.status_code == 200
+        assert response["Content-Encoding"] == "identity"
+
+        # Gzip content would not decode directly as UTF-8.
+        body = b"".join(response.streaming_content).decode("utf-8")
+        assert "event: log" in body
+        assert "event: result" in body
+
     @mock.patch("apprise.Apprise.notify")
     def test_notify_stream_via_query_string(self, mock_notify):
         """The stream query parameter works without an Accept header."""
@@ -1803,21 +2450,42 @@ class NotifyTests(SimpleTestCase):
         assert "event: result" in body
 
     @mock.patch("apprise.Apprise.notify")
-    def test_notify_stream_reports_error(self, mock_notify):
+    def test_notify_stream_ignores_empty_query_value(self, mock_notify):
+        """An empty stream parameter uses the normal response."""
+        mock_notify.return_value = notify_result(True)
+
+        key = "test_notify_stream_ignores_empty_query_value"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        response = self.client.post("/notify/{}?stream=".format(key), {"body": "hello"})
+        assert response.status_code == 200
+        assert response["Content-Type"] != "text/event-stream"
+
+    @mock.patch("api.views.send_webhook")
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_reports_error(self, mock_notify, mock_webhook):
         """Notification exceptions end the stream with an error event."""
         mock_notify.side_effect = ValueError("boom")
+        payload = {}
+
+        # Capture the generated failure payload inside the worker thread.
+        mock_webhook.side_effect = lambda chunks: payload.update(json.loads("".join(chunks)))
 
         key = "test_notify_stream_reports_an_unexpected_notify_failure"
         response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
         assert response.status_code == 200
 
-        response = self.client.post(
-            "/notify/{}".format(key),
-            {"body": "hello"},
-            HTTP_ACCEPT="text/event-stream",
-        )
-        assert response.status_code == 200
+        with override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"):
+            response = self.client.post(
+                "/notify/{}".format(key),
+                {"body": "hello"},
+                HTTP_ACCEPT="text/event-stream",
+            )
+            assert response.status_code == 200
+            body = b"".join(response.streaming_content).decode("utf-8")
 
-        body = b"".join(response.streaming_content).decode("utf-8")
         assert "event: error" in body
-        assert "boom" in body
+        assert "Notification processing failed." in body
+        assert "boom" not in body
+        assert payload["status"] == 1

--- a/apprise_api/api/tests/test_settings.py
+++ b/apprise_api/api/tests/test_settings.py
@@ -23,9 +23,11 @@
 # THE SOFTWARE.
 
 import importlib.util
+import logging
 import os
 from unittest import mock
 
+from core.utils import parse_bool, parse_log_level
 from django.conf import global_settings
 from django.test import SimpleTestCase
 
@@ -50,6 +52,80 @@ def _load_settings(extra_env=None):
     with mock.patch.dict(os.environ, env, clear=True):
         spec.loader.exec_module(mod)
     return mod
+
+
+class BooleanParsingTests(SimpleTestCase):
+    """Test the shared loose boolean convention."""
+
+    def test_true_prefixes(self):
+        """Common affirmative prefixes are accepted."""
+        # Every value begins with one of the supported truthy characters.
+        for value in ("active", "yes", "1", "true", "enable", "+", "  Enabled"):
+            self.assertTrue(parse_bool(value))
+
+    def test_false_and_empty_values(self):
+        """Negative and empty values use the expected fallback."""
+        # Unrecognized prefixes keep the normal false default.
+        for value in ("no", "false", "0", "disabled", "", "   ", None):
+            self.assertFalse(parse_bool(value))
+
+        # Empty input can also preserve a caller-supplied true default.
+        self.assertTrue(parse_bool("", default=True))
+
+
+class LogLevelParsingTests(SimpleTestCase):
+    """Test shared notification log-level parsing."""
+
+    def test_valid_levels(self):
+        """Supported names map to their logging values."""
+        self.assertEqual(parse_log_level(" info "), logging.INFO)
+        self.assertEqual(parse_log_level("TRACE"), logging.DEBUG - 1)
+
+    def test_invalid_levels_use_safe_fallbacks(self):
+        """Invalid request and configured values fall back safely."""
+        self.assertEqual(parse_log_level("invalid", "ERROR"), logging.ERROR)
+        self.assertEqual(parse_log_level("invalid", "invalid"), logging.WARNING)
+
+
+class StreamSizeSettingsTests(SimpleTestCase):
+    """Validate live-stream memory and disk size settings."""
+
+    def test_defaults_and_overrides(self):
+        """Stream sizes use MB environment values and documented defaults."""
+        # Load once without overrides to verify the shipped allowances.
+        defaults = _load_settings()
+        self.assertEqual(defaults.APPRISE_STREAM_MEMORY_SIZE, 2 * 1048576)
+        self.assertEqual(defaults.APPRISE_STREAM_DISK_SIZE, 256 * 1048576)
+
+        # Environment values are whole megabytes and become bytes at startup.
+        configured = _load_settings(
+            {
+                "APPRISE_STREAM_MEMORY_SIZE": "4",
+                "APPRISE_STREAM_DISK_SIZE": "8",
+            }
+        )
+        self.assertEqual(configured.APPRISE_STREAM_MEMORY_SIZE, 4 * 1048576)
+        self.assertEqual(configured.APPRISE_STREAM_DISK_SIZE, 8 * 1048576)
+
+    def test_zero_is_allowed(self):
+        """Zero remains available for each documented fallback mode."""
+        # Operators can explicitly disable either buffering layer.
+        configured = _load_settings(
+            {
+                "APPRISE_STREAM_MEMORY_SIZE": "0",
+                "APPRISE_STREAM_DISK_SIZE": "0",
+            }
+        )
+        self.assertEqual(configured.APPRISE_STREAM_MEMORY_SIZE, 0)
+        self.assertEqual(configured.APPRISE_STREAM_DISK_SIZE, 0)
+
+    def test_invalid_values_fail_at_startup(self):
+        """Negative, fractional, and non-numeric sizes are rejected."""
+        # Apply every invalid shape to both supported size settings.
+        for name in ("APPRISE_STREAM_MEMORY_SIZE", "APPRISE_STREAM_DISK_SIZE"):
+            for value in ("-1", "1.5", "many"):
+                with self.subTest(name=name, value=value), self.assertRaisesRegex(ValueError, name):
+                    _load_settings({name: value})
 
 
 class BaseUrlParsingTests(SimpleTestCase):

--- a/apprise_api/api/tests/test_settings.py
+++ b/apprise_api/api/tests/test_settings.py
@@ -87,6 +87,32 @@ class LogLevelParsingTests(SimpleTestCase):
         self.assertEqual(parse_log_level("invalid", "invalid"), logging.WARNING)
 
 
+class LogLevelSettingsTests(SimpleTestCase):
+    """Ensure the configured console level is always safe for Django."""
+
+    def test_valid_levels_are_normalized(self):
+        """Whitespace and custom TRACE values become known level names."""
+        for value, expected in ((" error ", "ERROR"), ("TRACE", "TRACE")):
+            with self.subTest(value=value):
+                configured = _load_settings({"LOG_LEVEL": value})
+                self.assertEqual(configured.APPRISE_LOG_LEVEL, expected)
+                self.assertEqual(
+                    configured.LOGGING["handlers"]["console"]["level"],
+                    expected,
+                )
+
+    def test_invalid_level_uses_runtime_default(self):
+        """A bad environment value cannot prevent application startup."""
+        configured = _load_settings({"LOG_LEVEL": "not-a-level"})
+
+        # Tests load normal production settings, where DEBUG is disabled.
+        self.assertEqual(configured.APPRISE_LOG_LEVEL, "INFO")
+        self.assertEqual(
+            configured.LOGGING["handlers"]["console"]["level"],
+            "INFO",
+        )
+
+
 class StreamSizeSettingsTests(SimpleTestCase):
     """Validate live-stream memory and disk size settings."""
 

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -66,7 +66,7 @@ class StatelessNotifyTests(SimpleTestCase):
         ]
 
     @mock.patch("apprise.Apprise.notify")
-    def test_notify_accepts_advanced_tag_expression_from_query_string(self, mock_notify):
+    def test_notify_accepts_query_tag_expression(self, mock_notify):
         """
         Stateless notify should accept tag and tags query-string fallbacks.
         """
@@ -767,8 +767,9 @@ class StatelessNotifyTests(SimpleTestCase):
         assert response.status_code == 200
         assert mock_notify.call_count == 1
         assert response["Content-Type"].startswith("text/html")
-        assert b'<ul class="logs">' in response.content
-        assert b'class="logs"' in response.content
+        # Standard notification output is now streamed in bounded chunks.
+        body = b"".join(response.streaming_content)
+        assert b'<ul class="logs">' in body
 
     @mock.patch("apprise.Apprise.notify")
     def test_notify_by_loaded_urls_with_json(self, mock_notify):
@@ -1143,7 +1144,7 @@ class StatelessNotifyTests(SimpleTestCase):
         assert mock_notify.call_count == 1
 
     @mock.patch("apprise.Apprise.notify")
-    def test_notify_stream_emits_log_and_result_events(self, mock_notify):
+    def test_notify_streams_logs_and_result(self, mock_notify):
         """Stateless notifications can stream progress and results live."""
         fake_service = type("FakeService", (), {"service_name": "JSON"})()
 
@@ -1171,3 +1172,51 @@ class StatelessNotifyTests(SimpleTestCase):
         assert "event: result" in body
         assert '"status": "SUCCESS"' in body
         assert "yahoo.ca" not in body
+
+    @mock.patch("api.views.send_webhook")
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_sends_webhook(self, mock_notify, mock_webhook):
+        """Stateless streams send their completion webhook."""
+        mock_notify.return_value = notify_result(True)
+        payload = {}
+
+        # Consume the bounded webhook while its result storage is still open.
+        mock_webhook.side_effect = lambda chunks: payload.update(json.loads("".join(chunks)))
+
+        with override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"):
+            response = self.client.post(
+                "/notify",
+                {"urls": "mailto://user:pass@yahoo.ca", "body": "hello"},
+                HTTP_ACCEPT="text/event-stream",
+            )
+            b"".join(response.streaming_content)
+
+        mock_webhook.assert_called_once()
+        assert payload["status"] == 0
+        assert isinstance(payload["output"], list)
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_skips_gzip(self, mock_notify):
+        """Stateless event streams remain uncompressed for live delivery."""
+        fake_service = type("FakeService", (), {"service_name": "JSON"})()
+
+        def fake_notify(*args, **kwargs):
+            kwargs["log_callback"](
+                apprise.NotifyLogEntry(level="INFO", message="Sent JSON POST notification."),
+                fake_service,
+            )
+            return notify_result(True)
+
+        mock_notify.side_effect = fake_notify
+
+        response = self.client.post(
+            "/notify?stream=yes",
+            {"urls": "mailto://user:pass@yahoo.ca", "body": "hello"},
+            HTTP_ACCEPT_ENCODING="gzip, deflate",
+        )
+        assert response.status_code == 200
+        assert response["Content-Encoding"] == "identity"
+
+        body = b"".join(response.streaming_content).decode("utf-8")
+        assert "event: log" in body
+        assert "event: result" in body

--- a/apprise_api/api/tests/test_stateless_notify.py
+++ b/apprise_api/api/tests/test_stateless_notify.py
@@ -32,6 +32,7 @@ from django.test.utils import override_settings
 import requests
 
 from ..forms import NotifyByUrlForm
+from .helpers import notify_result
 
 # Grant access to our Notification Manager Singleton
 N_MGR = apprise.manager_plugins.NotificationManager()
@@ -47,7 +48,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
         Stateless notify should also respect tag filters when provided.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         response = self.client.post(
             "/notify",
@@ -69,7 +70,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
         Stateless notify should accept tag and tags query-string fallbacks.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         payload = {
             "urls": "mailto://user:pass@hotmail.com",
@@ -90,7 +91,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
         Stateless notify should pass list-form JSON tags through as-is.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         response = self.client.post(
             "/notify",
@@ -150,7 +151,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # Preare our form data
         form_data = {
@@ -578,7 +579,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         headers = {
             "HTTP_X-APPRISE-ID": "abc123",
@@ -675,7 +676,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # Preare our form data (without url specified)
         # content will fall back to default configuration
@@ -706,7 +707,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # Preare our JSON data
         json_data = {
@@ -746,7 +747,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
         Test HTML log formatting block is triggered in StatelessNotifyView
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
         form_data = {
             "urls": "json://user@localhost",
             "body": "Testing HTML block",
@@ -776,7 +777,7 @@ class StatelessNotifyTests(SimpleTestCase):
         """
 
         # Set our return value
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # Preare our JSON data without any urls
         json_data = {
@@ -1039,7 +1040,7 @@ class StatelessNotifyTests(SimpleTestCase):
         Test that posting a form with an invalid choice field causes the form
         to fail validation, leaving content empty and returning 400.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # An invalid 'format' choice value makes NotifyByUrlForm invalid —
         # the form False branch is taken and we get a 400 response.
@@ -1056,7 +1057,7 @@ class StatelessNotifyTests(SimpleTestCase):
         Test that a JSON payload with an explicit empty 'format' field causes
         body_format to be falsy, skipping the body_format kwarg assignment.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # JSON payload with format="" — body_format is "" (falsy) so the
         # 'if body_format:' branch is not taken
@@ -1076,7 +1077,7 @@ class StatelessNotifyTests(SimpleTestCase):
         every branch in the level-to-int conversion chain, covering the final
         'elif level == "TRACE"' False branch.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         from django.conf import settings as _settings
 
@@ -1106,7 +1107,7 @@ class StatelessNotifyTests(SimpleTestCase):
 
         A missing subfield path must return 400 and not attempt to send.
         """
-        mock_notify.return_value = True
+        mock_notify.return_value = notify_result(True)
 
         # Missing subfield — form POST, plain-text response → 400
         with self.assertLogs("django", level="WARNING") as _:
@@ -1140,3 +1141,33 @@ class StatelessNotifyTests(SimpleTestCase):
         )
         assert response.status_code == 200
         assert mock_notify.call_count == 1
+
+    @mock.patch("apprise.Apprise.notify")
+    def test_notify_stream_emits_log_and_result_events(self, mock_notify):
+        """Stateless notifications can stream progress and results live."""
+        fake_service = type("FakeService", (), {"service_name": "JSON"})()
+
+        def fake_notify(*args, **kwargs):
+            log_callback = kwargs["log_callback"]
+            log_callback(
+                apprise.NotifyLogEntry(level="INFO", message="Sent JSON POST notification."),
+                fake_service,
+            )
+            return notify_result(True)
+
+        mock_notify.side_effect = fake_notify
+
+        response = self.client.post(
+            "/notify",
+            {"urls": "mailto://user:pass@yahoo.ca", "body": "hello"},
+            HTTP_ACCEPT="text/event-stream",
+        )
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/event-stream"
+
+        body = b"".join(response.streaming_content).decode("utf-8")
+        assert "event: log" in body
+        assert "Sent JSON POST notification." in body
+        assert "event: result" in body
+        assert '"status": "SUCCESS"' in body
+        assert "yahoo.ca" not in body

--- a/apprise_api/api/tests/test_webhook.py
+++ b/apprise_api/api/tests/test_webhook.py
@@ -21,6 +21,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+import io
 from json import loads
 from unittest import mock
 
@@ -32,6 +33,115 @@ from ..utils import send_webhook
 
 
 class WebhookTests(SimpleTestCase):
+    @mock.patch("requests.post")
+    def test_webhook_spools_large_payload(self, mock_post):
+        """Chunked webhook JSON is prepared on disk and read by requests."""
+        captured = {}
+
+        def post(_url, **kwargs):
+            """Read the file while send_webhook still owns it."""
+            captured["payload"] = loads(kwargs["data"].read())
+            response = mock.Mock()
+            response.status_code = requests.codes.ok
+            return response
+
+        mock_post.side_effect = post
+
+        chunks = iter(("{", '"status":0,', '"output":[]', "}"))
+        with override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"):
+            send_webhook(chunks)
+
+        assert captured["payload"] == {"status": 0, "output": []}
+
+    @mock.patch("requests.post")
+    def test_webhook_contains_spool_failures(self, mock_post):
+        """Webhook buffering failures are logged without making a request."""
+        with (
+            mock.patch(
+                "apprise_api.api.utils.tempfile.TemporaryFile",
+                side_effect=OSError("disk unavailable"),
+            ),
+            override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"),
+            self.assertLogs("django", level="WARNING"),
+        ):
+            send_webhook(iter(("{}",)))
+
+        mock_post.assert_not_called()
+
+        class ShortWriteFile(io.BytesIO):
+            """Report that only part of the first chunk was written."""
+
+            def write(self, value):
+                super().write(value[:-1])
+                return len(value) - 1
+
+        with (
+            mock.patch(
+                "apprise_api.api.utils.tempfile.TemporaryFile",
+                return_value=ShortWriteFile(),
+            ),
+            override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"),
+            self.assertLogs("django", level="WARNING"),
+        ):
+            send_webhook(iter(("{}",)))
+
+        mock_post.assert_not_called()
+
+    @mock.patch("requests.post")
+    def test_webhook_contains_mapping_serialization_failure(self, mock_post):
+        """Invalid mapping content is reported without making a request."""
+        payload = {"unsupported": object()}
+
+        with (
+            override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"),
+            self.assertLogs("django", level="WARNING"),
+        ):
+            # JSON preparation may fail before any network work begins.
+            send_webhook(payload)
+
+        mock_post.assert_not_called()
+
+    @mock.patch("requests.post")
+    def test_webhook_contains_cleanup_failure(self, mock_post):
+        """A close error is reported after a buffered webhook is sent."""
+
+        class CloseFailFile(io.BytesIO):
+            """Store normally but fail the first cleanup request."""
+
+            failed = False
+
+            def close(self):
+                if not self.failed:
+                    self.failed = True
+                    raise OSError("close failed")
+
+                super().close()
+
+        spool = CloseFailFile()
+
+        def post(_url, **kwargs):
+            """Read the complete request while the temporary file is open."""
+            assert loads(kwargs["data"].read()) == {}
+            response = mock.Mock()
+            response.status_code = requests.codes.ok
+            return response
+
+        mock_post.side_effect = post
+
+        with (
+            mock.patch(
+                "apprise_api.api.utils.tempfile.TemporaryFile",
+                return_value=spool,
+            ),
+            override_settings(APPRISE_WEBHOOK_URL="https://localhost/webhook"),
+            self.assertLogs("django", level="WARNING"),
+        ):
+            send_webhook(iter(("{}",)))
+
+        mock_post.assert_called_once()
+        # Finish cleanup after exercising the contained first failure.
+        spool.close()
+
     @mock.patch("requests.post")
     def test_webhook_testing(self, mock_post):
         """
@@ -123,14 +233,16 @@ class WebhookTests(SimpleTestCase):
         response.status_code = requests.codes.internal_server_error
         mock_post.return_value = response
         with override_settings(APPRISE_WEBHOOK_URL="http://localhost"):
-            send_webhook({})
+            with self.assertLogs("django", level="WARNING"):
+                send_webhook({})
             assert mock_post.call_count == 1
 
         mock_post.reset_mock()
 
         # A valid URL with a bad server response:
         mock_post.return_value = None
-        mock_post.side_effect = requests.RequestException("error")
+        mock_post.side_effect = requests.Timeout("timed out")
         with override_settings(APPRISE_WEBHOOK_URL="http://localhost"):
-            send_webhook({})
+            with self.assertLogs("django", level="WARNING"):
+                send_webhook({})
             assert mock_post.call_count == 1

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -23,6 +23,7 @@
 # THE SOFTWARE.
 import base64
 import binascii
+from collections.abc import Mapping
 from contextlib import suppress
 from datetime import datetime
 import errno
@@ -95,12 +96,8 @@ A_MGR = apprise.manager_attachment.AttachmentManager()
 # Access our Notification Manager Singleton
 N_MGR = apprise.manager_plugins.NotificationManager()
 
-# Opt into library eviction: when APPRISE_ALLOW_SERVICES or
-# APPRISE_DENY_SERVICES disables a plugin whose optional dependencies are
-# no longer needed by any other enabled plugin, the Apprise API actively
-# removes those modules from sys.modules to reclaim memory.  This is an
-# API-specific choice; third-party embedders of the Apprise library default
-# to False and retain all loaded modules.
+# Let the API unload optional modules that no enabled service still needs.
+# Other applications embedding Apprise keep loaded modules by default.
 N_MGR.evict_on_disable = True
 
 # Prepare our Attachment URL Filter
@@ -802,9 +799,7 @@ def gen_unique_config_id():
 
 
 def send_webhook(payload):
-    """
-    POST our webhook results
-    """
+    """POST a mapping or JSON chunk iterator to the webhook."""
 
     # Prepare HTTP Headers
     headers = {
@@ -837,10 +832,34 @@ def send_webhook(payload):
     # specified that aren't otherwise part of this class
     params = {k: v for k, v in results.get("qsd", {}).items() if k not in base.template_args}
 
+    # Prepare both forms inside the protected block below.
+    body = None
+    data = None
+
     try:
-        requests.post(
+        # A mapping remains convenient for small callers and existing tests.
+        data = dumps(payload) if isinstance(payload, Mapping) else None
+
+        if data is None:
+            # Build large webhook bodies on disk instead of joining every log.
+            body = tempfile.TemporaryFile(mode="w+b")  # noqa: SIM115
+
+            for chunk in payload:
+                # Convert text chunks before writing to the binary file.
+                value = chunk.encode("utf-8") if isinstance(chunk, str) else chunk
+
+                # Never send JSON after an incomplete write.
+                if body.write(value) != len(value):
+                    raise OSError("Incomplete webhook temporary-file write.")
+
+            # Rewind so the request reads from the beginning.
+            body.seek(0)
+            data = body
+
+        response = requests.post(
             base.request_url,
-            data=dumps(payload),
+            # Small mappings use text; chunked results use the file.
+            data=data,
             params=params,
             headers=headers,
             auth=base.request_auth,
@@ -848,9 +867,35 @@ def send_webhook(payload):
             timeout=base.request_timeout,
         )
 
+        # Report HTTP failures even when the connection itself succeeded.
+        if not 200 <= response.status_code < 300:
+            logger.warning(
+                "The Apprise Webhook Result URL returned HTTP %d: %s",
+                response.status_code,
+                base.url(privacy=True),
+            )
+
     except requests.RequestException as e:
         logger.warning("A Connection error occurred sending the Apprise Webhook results to %s.", base.url(privacy=True))
         logger.debug("Socket Exception: %s", str(e))
+
+    except (OSError, TypeError, ValueError) as e:
+        # Preparation failures must not change the notification result.
+        logger.warning(
+            "The Apprise Webhook results could not be prepared for %s.",
+            base.url(privacy=True),
+        )
+        logger.debug("Webhook preparation exception: %s", str(e))
+
+    finally:
+        if body is not None:
+            try:
+                # TemporaryFile removes the buffered webhook when closed.
+                body.close()
+
+            except (OSError, ValueError) as e:
+                logger.warning("The Apprise Webhook temporary file could not be closed.")
+                logger.debug("Webhook cleanup exception: %s", str(e))
 
     return
 

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -20,14 +20,19 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from collections import deque
 import json
 import logging
 import queue
 import re
+import struct
+import tempfile
 import threading
+import time
 from urllib.parse import parse_qs, urlsplit
 
 import apprise
+from core.utils import parse_bool, parse_log_level
 from django.conf import settings
 from django.core.exceptions import RequestDataTooBig
 from django.core.serializers.json import DjangoJSONEncoder
@@ -74,8 +79,360 @@ MIME_IS_FORM = re.compile(r"(multipart|application)/(x-www-)?form-(data|urlencod
 # <blank>
 ACCEPT_ALL = re.compile(r"^\s*([*]/[*]|)\s*$", re.I)
 
-# Matches requests for live notification progress via Server-Sent Events.
-MIME_IS_EVENT_STREAM = re.compile(r"text/event-stream", re.I)
+# Each disk entry starts with its byte length.
+_EVENT_SIZE = struct.Struct("!Q")
+
+# Report the first event moved to disk.
+_STREAM_PUT_SPOOLED = "spooled"
+
+# Report an event that could not be retained.
+_STREAM_PUT_FAILED = "failed"
+
+# This safe message is shown to a client after temporary storage is lost.
+_STREAM_STORAGE_WARNING = (
+    "Live log delivery reached a server storage limit or error. Some log "
+    "entries may be unavailable, but notification processing is continuing. "
+    "Please contact the server administrator."
+)
+
+
+def _safe_stream_log(level, message, *args, exc_info=None):
+    """Write an operational log without affecting notification delivery."""
+    try:  # noqa: SIM105 - keep the reason for suppressing handler failures clear.
+        logger.log(level, message, *args, exc_info=exc_info)
+    except Exception:
+        # A custom or broken logging handler must not stop notification work.
+        pass
+
+
+class _SpooledEventQueue:
+    """Keep a FIFO event stream in memory, then an anonymous temp file."""
+
+    def __init__(
+        self,
+        memory_bytes=None,
+        disk_bytes=None,
+    ):
+        # Keep this much waiting log data in memory before using disk.
+        # Tests may provide a value instead of using the server setting.
+        self._memory_byte_limit = settings.APPRISE_STREAM_MEMORY_SIZE if memory_bytes is None else memory_bytes
+
+        # Limit temporary disk use for this response.
+        self._disk_byte_limit = settings.APPRISE_STREAM_DISK_SIZE if disk_bytes is None else disk_bytes
+
+        # Memory holds the oldest events until its allowance is filled.
+        self._memory = deque()
+
+        # Count encoded bytes so non-ASCII text uses the correct allowance.
+        self._memory_bytes = 0
+
+        # Producers wake the response thread whenever a new event is ready.
+        self._condition = threading.Condition()
+
+        # Open the temporary file only when memory is full.
+        self._spool = None
+
+        # Point to the next disk event to read.
+        self._read_offset = 0
+
+        # Point to where the next complete disk event will be written.
+        self._write_offset = 0
+
+        # Number of complete events currently waiting on disk.
+        self._disk_count = 0
+
+        # Number of retained events still waiting for the client.
+        self._backlog = 0
+
+        # Largest backlog observed during this response.
+        self._max_backlog = 0
+
+        # Total number of events moved to temporary disk storage.
+        self._spooled_count = 0
+
+        # Total number of events that could not be retained.
+        self._unavailable_count = 0
+
+        # Report the first move to disk only once.
+        self._reported_slow = False
+
+        # Tell the response generator to send one visible storage warning.
+        self._storage_failed = False
+
+        # Avoid repeated disk work after temporary storage itself fails.
+        self._disk_unavailable = False
+
+        # Closed queues ignore entries produced after a client disconnects.
+        self._closed = False
+
+    def put(self, event):
+        """Queue an event and report the first spill or storage failure."""
+        with self._condition:
+            # A disconnected response no longer accepts log events.
+            if self._closed:
+                return None
+
+            # Limits are measured in encoded bytes, matching disk usage.
+            payload = event.encode("utf-8")
+
+            # A zero disk limit intentionally retains all events in memory.
+            memory_only = self._disk_byte_limit == 0 and self._memory_byte_limit > 0
+
+            if self._spool is None and (
+                memory_only
+                or (self._memory_byte_limit > 0 and self._memory_bytes + len(payload) <= self._memory_byte_limit)
+            ):
+                # Keep early events in memory while space remains.
+                self._memory.append((event, len(payload)))
+                self._memory_bytes += len(payload)
+
+            else:
+                if not self._disk_byte_limit:
+                    # Both limits are zero, so backlog retention is disabled.
+                    self._record_storage_limit("Notification stream buffering is disabled.")
+                    self._unavailable_count += 1
+
+                    return _STREAM_PUT_FAILED
+
+                if self._disk_unavailable:
+                    # Keep notification work moving after storage is lost.
+                    self._unavailable_count += 1
+
+                    return None
+
+                # Remember where valid disk content ends before writing.
+                previous_offset = self._write_offset
+
+                # Prefix the event with its size so it can be read safely.
+                record = _EVENT_SIZE.pack(len(payload)) + payload
+
+                if previous_offset + len(record) > self._disk_byte_limit:
+                    self._record_storage_limit("Notification stream reached its configured temporary storage limit.")
+                    self._unavailable_count += 1
+
+                    return _STREAM_PUT_FAILED
+
+                if self._spool is None:
+                    # TemporaryFile is unlinked automatically when closed.
+                    # It stays open until the stream drains or disconnects.
+                    try:
+                        self._spool = tempfile.TemporaryFile(  # noqa: SIM115
+                            mode="w+b", buffering=0
+                        )
+                    except OSError as error:
+                        # Creation failure leaves existing memory untouched.
+                        self._record_storage_failure("creation", error)
+                        self._unavailable_count += 1
+
+                        return _STREAM_PUT_FAILED
+
+                try:
+                    # Write after the last complete event.
+                    self._spool.seek(previous_offset)
+                    if self._spool.write(record) != len(record):
+                        raise OSError("Temporary storage accepted an incomplete event.")
+                except (OSError, ValueError) as error:
+                    # Remove a partial tail while preserving earlier events.
+                    try:
+                        # Discard only the incomplete record at the file end.
+                        self._spool.seek(previous_offset)
+                        self._spool.truncate()
+
+                    except (OSError, ValueError):
+                        # The original write error remains the useful failure.
+                        pass
+
+                    self._record_storage_failure("write", error)
+                    self._unavailable_count += 1
+
+                    if not self._disk_count:
+                        # No valid disk events remain for a reader to collect.
+                        self._close_spool()
+
+                    return _STREAM_PUT_FAILED
+
+                # Advance the valid end only after the full record is written.
+                self._write_offset = previous_offset + len(record)
+
+                # This complete event is now available to the reader.
+                self._disk_count += 1
+
+                # Keep a lifetime total even after this event is read.
+                self._spooled_count += 1
+
+            # Count only events that can still be delivered to the client.
+            self._backlog += 1
+
+            # Preserve the highest point for the final operational log.
+            self._max_backlog = max(self._max_backlog, self._backlog)
+
+            # Wake one response reader waiting for an event.
+            self._condition.notify()
+
+            if self._spool is not None and not self._reported_slow:
+                # Tell the caller only about the first move to disk.
+                self._reported_slow = True
+
+                return _STREAM_PUT_SPOOLED
+
+            return None
+
+    def get(self, timeout=None):
+        """Return the next event, waiting up to timeout when provided."""
+        # Use a fixed deadline so wakeups do not extend the requested wait.
+        deadline = time.monotonic() + timeout if timeout is not None else None
+
+        with self._condition:
+            while not self._backlog and not self._closed:
+                # Recalculate only the time left before the fixed deadline.
+                remaining = None if deadline is None else deadline - time.monotonic()
+
+                if remaining is not None and remaining <= 0:
+                    raise queue.Empty
+
+                # Sleep until a producer adds work, closes, or time expires.
+                self._condition.wait(remaining)
+
+            if not self._backlog:
+                # Closed and empty queues use the same signal as a timeout.
+                raise queue.Empty
+
+            if self._memory:
+                # Memory is older than disk because it was filled first.
+                event, size = self._memory.popleft()
+
+                # Return these bytes to the in-memory allowance.
+                self._memory_bytes -= size
+
+            else:
+                try:
+                    # Read exactly one length-prefixed event from disk.
+                    self._spool.seek(self._read_offset)
+
+                    # The first fixed-size value tells us how much text follows.
+                    size_data = self._spool.read(_EVENT_SIZE.size)
+
+                    if len(size_data) != _EVENT_SIZE.size:
+                        raise OSError("Incomplete event size in temporary storage.")
+
+                    size = _EVENT_SIZE.unpack(size_data)[0]
+
+                    # Read exactly the event size declared above.
+                    payload = self._spool.read(size)
+
+                    if len(payload) != size:
+                        raise OSError("Incomplete event in temporary storage.")
+
+                    # Events were stored as UTF-8 text by put().
+                    event = payload.decode("utf-8")
+
+                    # Point the next read just beyond this complete record.
+                    self._read_offset += _EVENT_SIZE.size + size
+
+                except (OSError, UnicodeError, ValueError) as error:
+                    # Drop unreadable disk entries but keep delivery running.
+                    self._record_storage_failure("read", error)
+
+                    # Every remaining disk event is now unavailable.
+                    self._unavailable_count += self._disk_count
+                    self._backlog -= self._disk_count
+                    self._disk_count = 0
+
+                    self._close_spool()
+
+                    raise queue.Empty from None
+
+                # One complete disk event was successfully restored.
+                self._disk_count -= 1
+
+                if not self._disk_count:
+                    # Release disk space as soon as the final event is read.
+                    self._close_spool()
+
+            # This event is no longer waiting for the client.
+            self._backlog -= 1
+
+            return event
+
+    def qsize(self):
+        """Return the number of events awaiting delivery."""
+        with self._condition:
+            return self._backlog
+
+    def storage_failed(self):
+        """Return whether temporary storage failed during this stream."""
+        with self._condition:
+            return self._storage_failed
+
+    def _record_storage_failure(self, operation, error):
+        """Record and report the first temporary-storage failure."""
+        if not self._disk_unavailable:
+            # Set this before logging because a custom handler may also fail.
+            self._storage_failed = True
+
+            # Future events can still use free memory, but no more disk writes.
+            self._disk_unavailable = True
+
+            _safe_stream_log(
+                logging.ERROR,
+                "Notification stream temporary storage %s failed; notification processing will continue.",
+                operation,
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    def _record_storage_limit(self, message):
+        """Report the first configured storage limit reached by a stream."""
+        if not self._storage_failed:
+            # The response generator turns this into one client-facing warning.
+            self._storage_failed = True
+
+            _safe_stream_log(logging.WARNING, message)
+
+    def _close_spool(self):
+        """Close temporary storage without allowing cleanup to escape."""
+        # Detach first so another cleanup attempt cannot reuse this handle.
+        spool, self._spool = self._spool, None
+
+        # A future spool starts from the beginning of a new temporary file.
+        self._read_offset = 0
+        self._write_offset = 0
+
+        if spool is not None:
+            try:
+                # TemporaryFile removes its anonymous content when closed.
+                spool.close()
+
+            except (OSError, ValueError) as error:
+                self._record_storage_failure("cleanup", error)
+
+    def close(self):
+        """Release temporary storage and return backlog statistics."""
+        with self._condition:
+            # Save counts before clearing the queue for the caller's logs.
+            self._closed = True
+            stats = (
+                self._backlog,
+                self._max_backlog,
+                self._spooled_count,
+                self._unavailable_count,
+            )
+
+            # Release all retained in-memory event text.
+            self._memory.clear()
+            self._memory_bytes = 0
+
+            # Closing the queue also removes its anonymous temporary file.
+            self._close_spool()
+
+            # The closed queue has no remaining deliverable events.
+            self._backlog = 0
+            self._disk_count = 0
+
+            # Wake readers so they can observe the closed, empty state.
+            self._condition.notify_all()
+
+            return stats
+
 
 # Tags separated by space, &, or + are and'ed together
 # Tags separated by commas (even commas wrapped in spaces) are "or'ed" together
@@ -202,48 +559,206 @@ def _notify_log_asctime(entry):
 
 
 def render_notify_logs(entries, json_response, content_type):
-    """
-    Render notification logs for the requested response format.
+    """Yield logs as JSON, HTML, or plain text.
 
-    JSON uses ``[level, time, message]`` entries, HTML uses a log list,
-    and plain text uses one entry per line.
+    Entries are read only as the response needs them, including logs stored on
+    disk.
     """
-    entries = list(entries)
-
     if json_response:
-        return [[entry.level, _notify_log_asctime(entry), entry.message] for entry in entries]
+        # Open the details array before reading its first log entry.
+        yield "["
+
+        separator = ""
+        for entry in entries:
+            # Encode one entry at a time.
+            yield separator
+            yield json.dumps(
+                [entry.level, _notify_log_asctime(entry), entry.message],
+                cls=JSONEncoder,
+                separators=(",", ":"),
+            )
+            separator = ","
+
+        yield "]"
+        return
 
     if content_type == "text/html":
-        return '<ul class="logs">{}</ul>'.format(
-            "".join(
+        # The surrounding list is sent even when no log entries were captured.
+        yield '<ul class="logs">'
+
+        for entry in entries:
+            # Escape plugin messages before placing them into HTML.
+            yield (
                 '<li class="log_{level}">'
                 '<div class="log_time">{time}</div>'
                 '<div class="log_level">{level}</div>'
-                '<div class="log_msg">{message}</div></li>'.format(
-                    level=entry.level,
-                    time=_notify_log_asctime(entry),
-                    message=escape(entry.message),
-                )
-                for entry in entries
+                '<div class="log_msg">{message}</div></li>'
+            ).format(
+                level=entry.level,
+                time=_notify_log_asctime(entry),
+                message=escape(entry.message),
             )
+
+        yield "</ul>"
+        return
+
+    # Plain text uses separators before later entries to avoid a trailing line.
+    separator = ""
+    for entry in entries:
+        yield separator
+        yield str(entry)
+        separator = "\n"
+
+
+def render_notify_response(
+    entries,
+    json_response,
+    content_type,
+    error=None,
+):
+    """Yield the complete HTTP response while keeping log entries lazy."""
+    if json_response:
+        # Preserve the documented response envelope around streamed details.
+        yield '{"error":'
+        yield json.dumps(error, cls=JSONEncoder, separators=(",", ":"))
+        yield ',"details":'
+        yield from render_notify_logs(entries, True, content_type)
+        yield "}"
+        return
+
+    # Track whether plain text produced anything before using an error fallback.
+    rendered = False
+    for chunk in render_notify_logs(entries, False, content_type):
+        rendered = True
+        yield chunk
+
+    if not rendered and error is not None:
+        # Match the earlier behavior when a failed call captured no text logs.
+        yield str(error)
+
+
+class _ResultLogResponse:
+    """Stream one result and close its temporary log storage."""
+
+    def __init__(self, result, json_response, content_type, error=None):
+        # The result remains open until Django finishes or closes this stream.
+        self._result = result
+
+        # JSON responses include an envelope around the streamed log details.
+        self._json_response = json_response
+
+        # HTML and plain-text renderers use this to choose their output shape.
+        self._content_type = content_type
+
+        # Failed notifications include this message in the response envelope.
+        self._error = error
+
+        # Closing is safe to request more than once.
+        self._closed = False
+
+    def __iter__(self):
+        """Yield response chunks and release storage after delivery."""
+        try:
+            yield from render_notify_response(
+                self._result.logs(),
+                self._json_response,
+                self._content_type,
+                error=self._error,
+            )
+
+        finally:
+            # Normal completion and interrupted iteration share cleanup.
+            self.close()
+
+    def close(self):
+        """Release disk-backed result logs when Django closes the response."""
+        if not self._closed:
+            self._closed = True
+
+            # AppriseResult.close() safely handles memory-only results too.
+            self._result.close()
+
+
+def stream_result_response(
+    result,
+    *,
+    json_response,
+    content_type,
+    status,
+    error=None,
+):
+    """Stream a response and release result storage when it closes."""
+    content = _ResultLogResponse(
+        result,
+        json_response,
+        content_type,
+        error=error,
+    )
+
+    response = StreamingHttpResponse(
+        content,
+        status=status,
+        content_type=content_type,
+    )
+
+    # Compression middleware may stream-compress this response safely.
+    return response
+
+
+def iter_notify_webhook(source, result):
+    """Yield a completion webhook without joining all result logs."""
+    yield '{"source":'
+    yield json.dumps(source, cls=JSONEncoder, separators=(",", ":"))
+
+    yield ',"status":'
+    yield "0" if result else "1"
+
+    yield ',"output":'
+    if result is None:
+        # Unexpected notification failures have no structured result to read.
+        yield json.dumps(
+            "Notification processing failed.",
+            cls=JSONEncoder,
+            separators=(",", ":"),
         )
 
-    # content_type == 'text/plain'
-    return "\n".join(str(entry) for entry in entries)
+    else:
+        # Webhook output keeps its established JSON log-list shape.
+        yield from render_notify_logs(
+            result.logs(),
+            True,
+            "application/json",
+        )
+
+    yield "}"
+
+
+def send_notify_webhook(source, result):
+    """Send the completion webhook without changing notification results."""
+    if settings.APPRISE_WEBHOOK_URL:
+        try:
+            # The utility spools these chunks to disk before making the request.
+            send_webhook(iter_notify_webhook(source, result))
+        except Exception:
+            # Expected URL and network failures are logged by send_webhook.
+            # This final guard covers an unexpected library or handler error.
+            _safe_stream_log(
+                logging.ERROR,
+                "Unexpected error while sending the completion webhook.",
+                exc_info=True,
+            )
 
 
 def _stream_requested(request):
     """
     Return whether the caller requested a live event stream.
 
-    Callers may use ``Accept: text/event-stream`` or the ``?stream=1``
-    shortcut when setting headers is inconvenient.
+    Use ``Accept: text/event-stream`` or a truthy ``?stream=`` value.
     """
-    return MIME_IS_EVENT_STREAM.search(request.headers.get("accept", "")) is not None or request.GET.get("stream") in (
-        "1",
-        "true",
-        "yes",
-    )
+    media_types = (value.partition(";")[0].strip().lower() for value in request.headers.get("accept", "").split(","))
+    if "text/event-stream" in media_types:
+        return True
+    return parse_bool(request.GET.get("stream"), default=False)
 
 
 def _sse_event(event, data):
@@ -251,33 +766,53 @@ def _sse_event(event, data):
     return "event: {}\ndata: {}\n\n".format(event, json.dumps(data, cls=JSONEncoder))
 
 
-def stream_notify_response(a_obj, *, body, title, notify_type, tag, attach, log_level, match_always=True):
+def stream_notify_response(
+    a_obj,
+    *,
+    body,
+    title,
+    notify_type,
+    tag,
+    attach,
+    log_level,
+    webhook_source=None,
+    match_always=True,
+):
     """
     Stream notification progress while ``notify()`` runs in the background.
 
     Log entries are sent as they occur. The stream ends with a ``result``
     event, or an ``error`` event if notification processing raises.
     """
-    events = queue.Queue()
-    done = object()
+    events = _SpooledEventQueue()
+    finished = threading.Event()
+    final_event = [_sse_event("error", {"message": "Notification processing failed."})]
 
     def log_callback(entry, service):
         # Apprise requires a synchronous callback; the queue safely passes
         # each entry to the response generator.
-        events.put(
-            _sse_event(
-                "log",
-                {
-                    "level": entry.level,
-                    "asctime": _notify_log_asctime(entry),
-                    "message": entry.message,
-                    # Include the service type, never its sensitive target URL.
-                    "service": getattr(service, "service_name", None),
-                },
-            )
+        event = _sse_event(
+            "log",
+            {
+                "level": entry.level,
+                "asctime": _notify_log_asctime(entry),
+                "message": entry.message,
+                # Include the service type, never its sensitive target URL.
+                "service": getattr(service, "service_name", None),
+            },
         )
+        queue_status = events.put(event)
+        if queue_status == _STREAM_PUT_SPOOLED:
+            # Record slow readers without delaying notification delivery.
+            _safe_stream_log(
+                logging.WARNING,
+                "Notification stream backlog moved to temporary storage.",
+            )
 
     def run():
+        # The worker owns notification processing and prepares one final event.
+        result = None
+
         try:
             result = a_obj.notify(
                 body,
@@ -289,33 +824,117 @@ def stream_notify_response(a_obj, *, body, title, notify_type, tag, attach, log_
                 log_level=log_level,
                 log_callback=log_callback,
             )
-            events.put(
-                _sse_event(
-                    "result",
-                    {"status": result.status.name if result.status is not None else None},
-                )
+            final_event[0] = _sse_event(
+                "result",
+                {"status": result.status.name if result.status is not None else None},
             )
-        except Exception as e:
-            events.put(_sse_event("error", {"message": str(e)}))
-        finally:
-            events.put(done)
 
-    # Standard threads work in tests and under gevent-enabled production workers.
-    threading.Thread(target=run, daemon=True).start()
+            # Webhook rendering walks logs in bounded chunks when configured.
+            send_notify_webhook(webhook_source, result)
+
+        except Exception:
+            # Log internal details without exposing them to the caller.
+            _safe_stream_log(
+                logging.ERROR,
+                "Notification streaming failed.",
+                exc_info=True,
+            )
+            send_notify_webhook(webhook_source, None)
+
+        finally:
+            if result is not None:
+                # Live events are already queued, so retained result storage
+                # can be released after optional webhook delivery finishes.
+                result.close()
+
+            # Wake the response loop even when notification work failed.
+            finished.set()
 
     def generator():
-        # Send an ignored SSE comment so headers arrive before the first event.
-        yield ": connected\n\n"
-        while True:
-            item = events.get()
-            if item is done:
-                return
-            yield item
+        storage_warning_sent = False
+        try:
+            # Start work when Django begins sending the response.
+            try:
+                threading.Thread(target=run, daemon=True).start()
+            except RuntimeError:
+                _safe_stream_log(
+                    logging.ERROR,
+                    "Notification streaming could not start.",
+                    exc_info=True,
+                )
+                finished.set()
+
+            # Send an ignored SSE comment so headers arrive immediately.
+            yield ": connected\n\n"
+            while True:
+                if events.storage_failed() and not storage_warning_sent:
+                    # This alert bypasses the failed temporary storage.
+                    storage_warning_sent = True
+                    entry = apprise.NotifyLogEntry(level="ERROR", message=_STREAM_STORAGE_WARNING)
+                    yield _sse_event(
+                        "log",
+                        {
+                            "level": entry.level,
+                            "asctime": _notify_log_asctime(entry),
+                            "message": entry.message,
+                            "service": None,
+                        },
+                    )
+                    continue
+
+                if events.qsize():
+                    try:
+                        yield events.get(timeout=0.25)
+                    except queue.Empty:
+                        continue
+                    continue
+
+                if finished.is_set():
+                    # All queued logs were sent, so the final event can follow.
+                    break
+
+                try:
+                    yield events.get(timeout=0.25)
+                except queue.Empty:
+                    continue
+
+            yield final_event[0]
+        finally:
+            # This also runs when the client disconnects mid-stream.
+            pending, max_backlog, spooled, unavailable = events.close()
+            if not finished.is_set():
+                # The client is gone, but notification work may still finish.
+                _safe_stream_log(
+                    logging.WARNING,
+                    "Notification stream closed before notification processing finished.",
+                )
+            if pending:
+                # The client is gone, so only normal server logging remains.
+                _safe_stream_log(
+                    logging.WARNING,
+                    "Notification stream closed with %d pending event(s).",
+                    pending,
+                )
+            if spooled:
+                _safe_stream_log(
+                    logging.INFO,
+                    "Notification stream spooled %d event(s); peak backlog was %d.",
+                    spooled,
+                    max_backlog,
+                )
+            if unavailable:
+                _safe_stream_log(
+                    logging.WARNING,
+                    "Notification stream could not retain %d log event(s).",
+                    unavailable,
+                )
 
     response = StreamingHttpResponse(generator(), content_type="text/event-stream")
     response["Cache-Control"] = "no-cache"
     # Prevent proxies such as nginx from batching streamed events.
     response["X-Accel-Buffering"] = "no"
+    # Compression can buffer events, so keep this response uncompressed.
+    response["Content-Encoding"] = "identity"
     return response
 
 
@@ -568,14 +1187,7 @@ class DetailsView(View):
 
         # Show All flag
         # Support 'yes', '1', 'true', 'enable', 'active', and +
-        show_all = request.GET.get("all", "no")[0].lower() in (
-            "a",
-            "y",
-            "1",
-            "t",
-            "e",
-            "+",
-        )
+        show_all = parse_bool(request.GET.get("all"), default=False)
 
         # Our status
         status = ResponseCode.okay
@@ -661,15 +1273,8 @@ class ConfigListView(View):
         """
         # Detect the format our response should be in.
         #
-        # This must check Accept first: Content-Type describes the
-        # *request* body, not the desired response, and a bodyless
-        # GET/POST still gets a Content-Type from the WSGI layer (commonly
-        # "text/plain" per the WSGI/CGI convention for an omitted
-        # Content-Type) even when the client never sent one - so checking
-        # it before Accept silently ignores an explicit
-        # "Accept: application/json" whenever there's no real request
-        # body, which is the common case for a JSON API client fetching
-        # data with a plain GET.
+        # Accept chooses the response format. Content-Type may be a server
+        # default on an empty request, so check Accept first.
         json_response = (
             MIME_IS_JSON.match(
                 request.headers.get("accept") or request.content_type or request.headers.get("content-type", "")
@@ -678,10 +1283,7 @@ class ConfigListView(View):
         )
 
         if settings.APPRISE_API_ONLY and not json_response:
-            # API Mode only disables the browsable HTML page; a JSON API
-            # request for the key list is still "the API" and stays
-            # available (subject to the APPRISE_ADMIN check below, same as
-            # ever - this only restores JSON access, not who may use it).
+            # API-only mode hides HTML. JSON still follows the admin check.
             return Error421View.as_view()(request)
 
         if not (settings.APPRISE_ADMIN and settings.APPRISE_STATEFUL_MODE == AppriseStoreMode.SIMPLE):
@@ -1094,15 +1696,8 @@ class DelView(View):
         """
         # Detect the format our response should be in.
         #
-        # This must check Accept first: Content-Type describes the
-        # *request* body, not the desired response, and a bodyless
-        # GET/POST still gets a Content-Type from the WSGI layer (commonly
-        # "text/plain" per the WSGI/CGI convention for an omitted
-        # Content-Type) even when the client never sent one - so checking
-        # it before Accept silently ignores an explicit
-        # "Accept: application/json" whenever there's no real request
-        # body, which is the common case for a JSON API client fetching
-        # data with a plain GET.
+        # Accept chooses the response format. Content-Type may be a server
+        # default on an empty request, so check Accept first.
         json_response = (
             MIME_IS_JSON.match(
                 request.headers.get("accept") or request.content_type or request.headers.get("content-type", "")
@@ -1727,7 +2322,9 @@ class NotifyView(View):
         #
         apply_global_filters()
 
-        # Prepare ourselves a default Asset
+        # Put result-log storage limits on the asset Apprise already receives.
+        kwargs["result_log_memory_size"] = settings.APPRISE_STREAM_MEMORY_SIZE
+        kwargs["result_log_disk_size"] = settings.APPRISE_STREAM_DISK_SIZE
         asset = apprise.AppriseAsset(**kwargs)
 
         # Prepare our apprise object
@@ -1764,45 +2361,11 @@ class NotifyView(View):
         else:
             content_type = "application/json"
 
-        # Acquire our log level from headers if defined, otherwise use
-        # the global one set in the settings
-        level = request.headers.get(
-            "X-Apprise-Log-Level",
+        # Use the request level when valid, then the configured default.
+        level = parse_log_level(
+            request.headers.get("X-Apprise-Log-Level"),
             settings.APPRISE_LOG_LEVEL,
-        ).upper()
-        if level not in (
-            "CRITICAL",
-            "ERROR",
-            "WARNING",
-            "INFO",
-            "DEBUG",
-            "TRACE",
-        ):
-            level = settings.APPRISE_LOG_LEVEL.upper()
-
-        # Convert level to it's integer value
-        if level == "CRITICAL":
-            level = logging.CRITICAL
-
-        elif level == "ERROR":
-            level = logging.ERROR
-
-        elif level == "WARNING":
-            level = logging.WARNING
-
-        elif level == "INFO":
-            level = logging.INFO
-
-        elif level == "DEBUG":
-            level = logging.DEBUG
-
-        elif level == "TRACE":
-            level = logging.DEBUG - 1
-
-        if not isinstance(level, int):
-            # The configured default log level is not a recognised value;
-            # fall back to WARNING so notify() receives a valid integer.
-            level = logging.WARNING
+        )
 
         if stream_response:
             # Return live progress while notification runs in the background.
@@ -1814,6 +2377,7 @@ class NotifyView(View):
                 tag=(content.get("tag") or None),
                 attach=attach,
                 log_level=level,
+                webhook_source=request.META.get("REMOTE_ADDR", ""),
             )
 
         # Capture notification logs at the caller's requested level.
@@ -1826,18 +2390,8 @@ class NotifyView(View):
             log_level=level,
         )
 
-        # Format the structured logs for the response.
-        response = render_notify_logs(result.logs(), json_response, content_type)
-
-        if settings.APPRISE_WEBHOOK_URL:
-            webhook_payload = {
-                "source": request.META["REMOTE_ADDR"],
-                "status": 0 if result else 1,
-                "output": response,
-            }
-
-            # Send our webhook (pass or fail)
-            send_webhook(webhook_payload)
+        # Send the optional webhook from a separate bounded walk of the logs.
+        send_notify_webhook(request.META.get("REMOTE_ADDR", ""), result)
 
         if not result:
             # If at least one notification couldn't be sent; change up
@@ -1850,22 +2404,12 @@ class NotifyView(View):
                 "" if not tag else f" (Tags: {tag})",
                 key,
             )
-            return (
-                HttpResponse(
-                    response if response else msg,
-                    status=status,
-                    content_type=content_type,
-                )
-                if not json_response
-                else JsonResponse(
-                    {
-                        "error": msg,
-                        "details": response,
-                    },
-                    encoder=JSONEncoder,
-                    safe=False,
-                    status=status,
-                )
+            return stream_result_response(
+                result,
+                json_response=json_response,
+                content_type=content_type,
+                status=status,
+                error=msg,
             )
 
         logger.info(
@@ -1877,18 +2421,11 @@ class NotifyView(View):
 
         # Return our success message
         status = ResponseCode.okay
-        return (
-            HttpResponse(response, status=status, content_type=content_type)
-            if not json_response
-            else JsonResponse(
-                {
-                    "error": None,
-                    "details": response,
-                },
-                encoder=JSONEncoder,
-                safe=False,
-                status=status,
-            )
+        return stream_result_response(
+            result,
+            json_response=json_response,
+            content_type=content_type,
+            status=status,
         )
 
 
@@ -2346,7 +2883,9 @@ class StatelessNotifyView(View):
         #
         apply_global_filters()
 
-        # Prepare ourselves a default Asset
+        # Put result-log storage limits on the asset Apprise already receives.
+        kwargs["result_log_memory_size"] = settings.APPRISE_STREAM_MEMORY_SIZE
+        kwargs["result_log_disk_size"] = settings.APPRISE_STREAM_DISK_SIZE
         asset = apprise.AppriseAsset(**kwargs)
 
         # Prepare our apprise object
@@ -2396,45 +2935,11 @@ class StatelessNotifyView(View):
         else:
             content_type = "application/json"
 
-        # Acquire our log level from headers if defined, otherwise use
-        # the global one set in the settings
-        level = request.headers.get(
-            "X-Apprise-Log-Level",
+        # Use the request level when valid, then the configured default.
+        level = parse_log_level(
+            request.headers.get("X-Apprise-Log-Level"),
             settings.APPRISE_LOG_LEVEL,
-        ).upper()
-        if level not in (
-            "CRITICAL",
-            "ERROR",
-            "WARNING",
-            "INFO",
-            "DEBUG",
-            "TRACE",
-        ):
-            level = settings.APPRISE_LOG_LEVEL.upper()
-
-        # Convert level to it's integer value
-        if level == "CRITICAL":
-            level = logging.CRITICAL
-
-        elif level == "ERROR":
-            level = logging.ERROR
-
-        elif level == "WARNING":
-            level = logging.WARNING
-
-        elif level == "INFO":
-            level = logging.INFO
-
-        elif level == "DEBUG":
-            level = logging.DEBUG
-
-        elif level == "TRACE":
-            level = logging.DEBUG - 1
-
-        if not isinstance(level, int):
-            # The configured default log level is not a recognised value;
-            # fall back to WARNING so notify() receives a valid integer.
-            level = logging.WARNING
+        )
 
         if stream_response:
             # Return live progress while notification runs in the background.
@@ -2446,6 +2951,7 @@ class StatelessNotifyView(View):
                 tag=(content.get("tag") or "all"),
                 attach=attach,
                 log_level=level,
+                webhook_source=request.META.get("REMOTE_ADDR", ""),
             )
 
         # Capture notification logs at the caller's requested level.
@@ -2458,18 +2964,8 @@ class StatelessNotifyView(View):
             log_level=level,
         )
 
-        # Format the structured logs for the response.
-        response = render_notify_logs(result.logs(), json_response, content_type)
-
-        if settings.APPRISE_WEBHOOK_URL:
-            webhook_payload = {
-                "source": request.META["REMOTE_ADDR"],
-                "status": 0 if result else 1,
-                "output": response,
-            }
-
-            # Send our webhook (pass or fail)
-            send_webhook(webhook_payload)
+        # Send the optional webhook from a separate bounded walk of the logs.
+        send_notify_webhook(request.META.get("REMOTE_ADDR", ""), result)
 
         if not result:
             # If at least one notification couldn't be sent; change up the
@@ -2482,22 +2978,12 @@ class StatelessNotifyView(View):
             status = ResponseCode.failed_dependency
             msg = _("One or more notifications could not be sent")
 
-            return (
-                HttpResponse(
-                    response if response else msg,
-                    status=status,
-                    content_type=content_type,
-                )
-                if not json_response
-                else JsonResponse(
-                    {
-                        "error": msg,
-                        "details": response,
-                    },
-                    encoder=JSONEncoder,
-                    safe=False,
-                    status=status,
-                )
+            return stream_result_response(
+                result,
+                json_response=json_response,
+                content_type=content_type,
+                status=status,
+                error=msg,
             )
 
         logger.info(
@@ -2507,18 +2993,11 @@ class StatelessNotifyView(View):
 
         # Return our success message
         status = ResponseCode.okay
-        return (
-            HttpResponse(response, status=status, content_type=content_type)
-            if not json_response
-            else JsonResponse(
-                {
-                    "error": None,
-                    "details": response,
-                },
-                encoder=JSONEncoder,
-                safe=False,
-                status=status,
-            )
+        return stream_result_response(
+            result,
+            json_response=json_response,
+            content_type=content_type,
+            status=status,
         )
 
 
@@ -2556,14 +3035,7 @@ class JsonUrlView(View):
 
         # Privacy flag
         # Support 'yes', '1', 'true', 'enable', 'active', and +
-        privacy = settings.APPRISE_CONFIG_LOCK or request.GET.get("privacy", "no")[0].lower() in (
-            "a",
-            "y",
-            "1",
-            "t",
-            "e",
-            "+",
-        )
+        privacy = settings.APPRISE_CONFIG_LOCK or parse_bool(request.GET.get("privacy"), default=False)
 
         # Optionally filter on tags. Use comma to identify more then one
         tag = request.GET.get("tag", "all")

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -22,14 +22,16 @@
 # THE SOFTWARE.
 import json
 import logging
+import queue
 import re
+import threading
 from urllib.parse import parse_qs, urlsplit
 
 import apprise
 from django.conf import settings
 from django.core.exceptions import RequestDataTooBig
 from django.core.serializers.json import DjangoJSONEncoder
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
@@ -71,6 +73,9 @@ MIME_IS_FORM = re.compile(r"(multipart|application)/(x-www-)?form-(data|urlencod
 # */*
 # <blank>
 ACCEPT_ALL = re.compile(r"^\s*([*]/[*]|)\s*$", re.I)
+
+# Matches requests for live notification progress via Server-Sent Events.
+MIME_IS_EVENT_STREAM = re.compile(r"text/event-stream", re.I)
 
 # Tags separated by space, &, or + are and'ed together
 # Tags separated by commas (even commas wrapped in spaces) are "or'ed" together
@@ -186,6 +191,132 @@ def service_optional(notification, url):
         pass
 
     return bool(optional)
+
+
+def _notify_log_asctime(entry):
+    """Format a notification log time as ``YYYY-MM-DD HH:MM:SS,mmm``."""
+    return "{},{:03d}".format(
+        entry.time.strftime("%Y-%m-%d %H:%M:%S"),
+        entry.time.microsecond // 1000,
+    )
+
+
+def render_notify_logs(entries, json_response, content_type):
+    """
+    Render notification logs for the requested response format.
+
+    JSON uses ``[level, time, message]`` entries, HTML uses a log list,
+    and plain text uses one entry per line.
+    """
+    entries = list(entries)
+
+    if json_response:
+        return [[entry.level, _notify_log_asctime(entry), entry.message] for entry in entries]
+
+    if content_type == "text/html":
+        return '<ul class="logs">{}</ul>'.format(
+            "".join(
+                '<li class="log_{level}">'
+                '<div class="log_time">{time}</div>'
+                '<div class="log_level">{level}</div>'
+                '<div class="log_msg">{message}</div></li>'.format(
+                    level=entry.level,
+                    time=_notify_log_asctime(entry),
+                    message=escape(entry.message),
+                )
+                for entry in entries
+            )
+        )
+
+    # content_type == 'text/plain'
+    return "\n".join(str(entry) for entry in entries)
+
+
+def _stream_requested(request):
+    """
+    Return whether the caller requested a live event stream.
+
+    Callers may use ``Accept: text/event-stream`` or the ``?stream=1``
+    shortcut when setting headers is inconvenient.
+    """
+    return MIME_IS_EVENT_STREAM.search(request.headers.get("accept", "")) is not None or request.GET.get("stream") in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _sse_event(event, data):
+    """Format one Server-Sent Event: a named event plus a JSON data line."""
+    return "event: {}\ndata: {}\n\n".format(event, json.dumps(data, cls=JSONEncoder))
+
+
+def stream_notify_response(a_obj, *, body, title, notify_type, tag, attach, log_level, match_always=True):
+    """
+    Stream notification progress while ``notify()`` runs in the background.
+
+    Log entries are sent as they occur. The stream ends with a ``result``
+    event, or an ``error`` event if notification processing raises.
+    """
+    events = queue.Queue()
+    done = object()
+
+    def log_callback(entry, service):
+        # Apprise requires a synchronous callback; the queue safely passes
+        # each entry to the response generator.
+        events.put(
+            _sse_event(
+                "log",
+                {
+                    "level": entry.level,
+                    "asctime": _notify_log_asctime(entry),
+                    "message": entry.message,
+                    # Include the service type, never its sensitive target URL.
+                    "service": getattr(service, "service_name", None),
+                },
+            )
+        )
+
+    def run():
+        try:
+            result = a_obj.notify(
+                body,
+                title=title,
+                notify_type=notify_type,
+                tag=tag,
+                match_always=match_always,
+                attach=attach,
+                log_level=log_level,
+                log_callback=log_callback,
+            )
+            events.put(
+                _sse_event(
+                    "result",
+                    {"status": result.status.name if result.status is not None else None},
+                )
+            )
+        except Exception as e:
+            events.put(_sse_event("error", {"message": str(e)}))
+        finally:
+            events.put(done)
+
+    # Standard threads work in tests and under gevent-enabled production workers.
+    threading.Thread(target=run, daemon=True).start()
+
+    def generator():
+        # Send an ignored SSE comment so headers arrive before the first event.
+        yield ": connected\n\n"
+        while True:
+            item = events.get()
+            if item is done:
+                return
+            yield item
+
+    response = StreamingHttpResponse(generator(), content_type="text/event-stream")
+    response["Cache-Control"] = "no-cache"
+    # Prevent proxies such as nginx from batching streamed events.
+    response["X-Accel-Buffering"] = "no"
+    return response
 
 
 class JSONEncoder(DjangoJSONEncoder):
@@ -1107,6 +1238,9 @@ class NotifyView(View):
             else MIME_IS_JSON.match(request.headers.get("accept", "")) is not None
         )
 
+        # Event streams use their own format instead of JSON, HTML, or text.
+        stream_response = _stream_requested(request)
+
         # rules
         rules = {k[1:]: v for k, v in request.GET.items() if k[0] == ":"}
 
@@ -1634,7 +1768,7 @@ class NotifyView(View):
         # the global one set in the settings
         level = request.headers.get(
             "X-Apprise-Log-Level",
-            settings.LOGGING["loggers"]["apprise"]["level"],
+            settings.APPRISE_LOG_LEVEL,
         ).upper()
         if level not in (
             "CRITICAL",
@@ -1644,7 +1778,7 @@ class NotifyView(View):
             "DEBUG",
             "TRACE",
         ):
-            level = settings.LOGGING["loggers"]["apprise"]["level"].upper()
+            level = settings.APPRISE_LOG_LEVEL.upper()
 
         # Convert level to it's integer value
         if level == "CRITICAL":
@@ -1667,67 +1801,33 @@ class NotifyView(View):
 
         if not isinstance(level, int):
             # The configured default log level is not a recognised value;
-            # fall back to WARNING so LogCapture receives a valid integer.
+            # fall back to WARNING so notify() receives a valid integer.
             level = logging.WARNING
 
-        # Initialize our response object
-        response = None
-
-        esc = "<!!-!ESC!-!!>"
-
-        if json_response:
-            fmt = f'["%(levelname)s","%(asctime)s","{esc}%(message)s{esc}"]'
-
-        else:
-            # Format is only updated if the content_type is html
-            fmt = (
-                '<li class="log_%(levelname)s">'
-                '<div class="log_time">%(asctime)s</div>'
-                '<div class="log_level">%(levelname)s</div>'
-                f'<div class="log_msg">{esc}%(message)s{esc}</div></li>'
-                if content_type == "text/html"
-                else settings.LOGGING["formatters"]["standard"]["format"]
-            )
-
-        # Now specify our format (and over-ride the default):
-        with apprise.LogCapture(level=level, fmt=fmt) as logs:
-            # Perform our notification at this point
-            result = a_obj.notify(
-                content.get("body"),
+        if stream_response:
+            # Return live progress while notification runs in the background.
+            return stream_notify_response(
+                a_obj,
+                body=content.get("body"),
                 title=content.get("title", ""),
                 notify_type=content.get("type", apprise.NotifyType.INFO.value),
                 tag=(content.get("tag") or None),
                 attach=attach,
+                log_level=level,
             )
 
-        if json_response:
-            esc = re.escape(esc)
-            entries = re.findall(
-                r'\r*\n?(?P<head>\["[^"]+","[^"]+",)"{}(?P<to_escape>.+?)'
-                r'{}"(?P<tail>\]\r*\n?$)(?=$|\r*\n?\["[^"]+","[^"]+","{})'.format(esc, esc, esc),
-                logs.getvalue(),
-                re.DOTALL | re.MULTILINE,
-            )
+        # Capture notification logs at the caller's requested level.
+        result = a_obj.notify(
+            content.get("body"),
+            title=content.get("title", ""),
+            notify_type=content.get("type", apprise.NotifyType.INFO.value),
+            tag=(content.get("tag") or None),
+            attach=attach,
+            log_level=level,
+        )
 
-            # Prepare ourselves a JSON Response
-            response = json.loads("[{}]".format(",".join([e[0] + json.dumps(e[1].rstrip()) + e[2] for e in entries])))
-
-        elif content_type == "text/html":
-            # Iterate over our entries so that we can prepare to escape
-            # things to be presented as HTML
-            esc = re.escape(esc)
-            entries = re.findall(
-                r'\r*\n?(?P<head><li class="log_.+?){}(?P<to_escape>.+?)'
-                r'{}(?P<tail></div></li>\r*\n?$)(?=$|\r*\n?<li class="log_.+{})'.format(esc, esc, esc),
-                logs.getvalue(),
-                re.DOTALL | re.MULTILINE,
-            )
-
-            # Wrap logs in `<ul>` tag and escape our message body:
-            response = '<ul class="logs">{}</ul>'.format("".join([e[0] + escape(e[1]) + e[2] for e in entries]))
-
-        else:  # content_type == 'text/plain'
-            response = logs.getvalue()
+        # Format the structured logs for the response.
+        response = render_notify_logs(result.logs(), json_response, content_type)
 
         if settings.APPRISE_WEBHOOK_URL:
             webhook_payload = {
@@ -1816,6 +1916,9 @@ class StatelessNotifyView(View):
             if json_payload and ACCEPT_ALL.match(request.headers.get("accept", ""))
             else MIME_IS_JSON.match(request.headers.get("accept", "")) is not None
         )
+
+        # Event streams use their own format instead of JSON, HTML, or text.
+        stream_response = _stream_requested(request)
 
         # rules
         rules = {k[1:]: v for k, v in request.GET.items() if k[0] == ":"}
@@ -2297,7 +2400,7 @@ class StatelessNotifyView(View):
         # the global one set in the settings
         level = request.headers.get(
             "X-Apprise-Log-Level",
-            settings.LOGGING["loggers"]["apprise"]["level"],
+            settings.APPRISE_LOG_LEVEL,
         ).upper()
         if level not in (
             "CRITICAL",
@@ -2307,7 +2410,7 @@ class StatelessNotifyView(View):
             "DEBUG",
             "TRACE",
         ):
-            level = settings.LOGGING["loggers"]["apprise"]["level"].upper()
+            level = settings.APPRISE_LOG_LEVEL.upper()
 
         # Convert level to it's integer value
         if level == "CRITICAL":
@@ -2330,67 +2433,33 @@ class StatelessNotifyView(View):
 
         if not isinstance(level, int):
             # The configured default log level is not a recognised value;
-            # fall back to WARNING so LogCapture receives a valid integer.
+            # fall back to WARNING so notify() receives a valid integer.
             level = logging.WARNING
 
-        # Initialize our response object
-        response = None
-
-        esc = "<!!-!ESC!-!!>"
-
-        if json_response:
-            fmt = f'["%(levelname)s","%(asctime)s","{esc}%(message)s{esc}"]'
-
-        else:
-            # Format is only updated if the content_type is html
-            fmt = (
-                '<li class="log_%(levelname)s">'
-                '<div class="log_time">%(asctime)s</div>'
-                '<div class="log_level">%(levelname)s</div>'
-                f'<div class="log_msg">{esc}%(message)s{esc}</div></li>'
-                if content_type == "text/html"
-                else settings.LOGGING["formatters"]["standard"]["format"]
-            )
-
-        # Now specify our format (and over-ride the default):
-        with apprise.LogCapture(level=level, fmt=fmt) as logs:
-            # Perform our notification at this point
-            result = a_obj.notify(
-                content.get("body"),
+        if stream_response:
+            # Return live progress while notification runs in the background.
+            return stream_notify_response(
+                a_obj,
+                body=content.get("body"),
                 title=content.get("title", ""),
                 notify_type=content.get("type", apprise.NotifyType.INFO.value),
                 tag=(content.get("tag") or "all"),
                 attach=attach,
+                log_level=level,
             )
 
-        if json_response:
-            esc = re.escape(esc)
-            entries = re.findall(
-                r'\r*\n?(?P<head>\["[^"]+","[^"]+",)"{}(?P<to_escape>.+?)'
-                r'{}"(?P<tail>\]\r*\n?$)(?=$|\r*\n?\["[^"]+","[^"]+","{})'.format(esc, esc, esc),
-                logs.getvalue(),
-                re.DOTALL | re.MULTILINE,
-            )
+        # Capture notification logs at the caller's requested level.
+        result = a_obj.notify(
+            content.get("body"),
+            title=content.get("title", ""),
+            notify_type=content.get("type", apprise.NotifyType.INFO.value),
+            tag=(content.get("tag") or "all"),
+            attach=attach,
+            log_level=level,
+        )
 
-            # Prepare ourselves a JSON Response
-            response = json.loads("[{}]".format(",".join([e[0] + json.dumps(e[1].rstrip()) + e[2] for e in entries])))
-
-        elif content_type == "text/html":
-            # Iterate over our entries so that we can prepare to escape
-            # things to be presented as HTML
-            esc = re.escape(esc)
-            entries = re.findall(
-                r'\r*\n?(?P<head><li class="log_.+?){}(?P<to_escape>.+?)'
-                r'{}(?P<tail></div></li>\r*\n?$)(?=$|\r*\n?<li class="log_.+{})'.format(esc, esc, esc),
-                logs.getvalue(),
-                re.DOTALL | re.MULTILINE,
-            )
-
-            # Wrap logs in `<ul>` tag and escape our message body:
-            response = '<ul class="logs">{}</ul>'.format("".join([e[0] + escape(e[1]) + e[2] for e in entries]))
-
-        else:  # content_type == 'text/plain'
-            response = logs.getvalue()
+        # Format the structured logs for the response.
+        response = render_notify_logs(result.logs(), json_response, content_type)
 
         if settings.APPRISE_WEBHOOK_URL:
             webhook_payload = {

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -26,6 +26,7 @@ import os
 
 import apprise
 from core.themes import SiteTheme
+from core.utils import parse_bool
 
 # Register apprise's custom log levels before Django's dictConfig() runs.
 if not hasattr(logging, "TRACE"):
@@ -66,14 +67,7 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "+reua88v8rs4j!bcfdtinb-f0edxazf!$x_q1
 #    ./manage.py runserver
 #
 # Support 'yes', '1', 'true', 'enable', 'active', and +
-DEBUG = os.environ.get("DEBUG", "No")[0].lower() in (
-    "a",
-    "y",
-    "1",
-    "t",
-    "e",
-    "+",
-)
+DEBUG = parse_bool(os.environ.get("DEBUG", "No"))
 
 # allow all hosts by default otherwise read from the
 # ALLOWED_HOSTS environment variable
@@ -268,6 +262,29 @@ APPRISE_ATTACH_ALLOW_URLS = os.environ.get("APPRISE_ATTACH_ALLOW_URL", "*").lowe
 # (defined in MB)
 APPRISE_UPLOAD_MAX_MEMORY_SIZE = abs(int(os.environ.get("APPRISE_UPLOAD_MAX_MEMORY_SIZE", 3))) * 1048576
 
+
+def _stream_size_setting(name, default):
+    """Return a non-negative whole-MB stream setting in bytes."""
+    try:
+        # Environment values arrive as text, while defaults are whole MB.
+        value = int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        raise ValueError(f"{name} must be a non-negative whole number of MB.") from None
+
+    if value < 0:
+        raise ValueError(f"{name} must be a non-negative whole number of MB.")
+
+    # Django and the buffering code work with bytes.
+    return value * 1048576
+
+
+# Live logs use memory first, then one temporary file for a slow client.
+# These same limits are placed on AppriseAsset for completed result logs.
+APPRISE_STREAM_MEMORY_SIZE = _stream_size_setting("APPRISE_STREAM_MEMORY_SIZE", 2)
+
+# This allowance bounds the temporary file shared by captured logs.
+APPRISE_STREAM_DISK_SIZE = _stream_size_setting("APPRISE_STREAM_DISK_SIZE", 256)
+
 # The maximum configuration payload size (in bytes) accepted by form/API
 # configuration updates. This value is configured in KB and converted to bytes
 # (KB * 1024). It is capped by APPRISE_UPLOAD_MAX_MEMORY_SIZE (bytes).
@@ -292,7 +309,7 @@ APPRISE_CONFIG_MAX_LENGTH = min(
 # The idea here is that someone has set up the configuration they way they want
 # and do not want this information exposed any more then it needs to be.
 # it's a lock down mode if you will.
-APPRISE_CONFIG_LOCK = os.environ.get("APPRISE_CONFIG_LOCK", "no")[0].lower() in ("a", "y", "1", "t", "e", "+")
+APPRISE_CONFIG_LOCK = parse_bool(os.environ.get("APPRISE_CONFIG_LOCK", "no"))
 
 # Stateless posts to /notify/ will resort to this set of URLs if none
 # were otherwise posted with the URL request.
@@ -300,14 +317,7 @@ APPRISE_STATELESS_URLS = os.environ.get("APPRISE_STATELESS_URLS", "")
 
 # Allow stateless URLS to generate and/or work with persistent storage
 # By default this is set to no
-APPRISE_STATELESS_STORAGE = os.environ.get("APPRISE_STATELESS_STORAGE", "no")[0].lower() in (
-    "a",
-    "y",
-    "1",
-    "t",
-    "e",
-    "+",
-)
+APPRISE_STATELESS_STORAGE = parse_bool(os.environ.get("APPRISE_STATELESS_STORAGE", "no"))
 
 # Defines the stateful mode; possible values are:
 # - hash (default): content is hashed and zipped
@@ -354,39 +364,15 @@ APPRISE_WEBHOOK_MAPPING_MAX_DEPTH = abs(int(os.environ.get("APPRISE_WEBHOOK_MAPP
 # - Website requests returns 421 (Misdirected Request) for what would otherwise
 #   have been part of the Apprise Website host if this is set to 'no'.
 # - The default value of this is 'no'
-APPRISE_API_ONLY = os.environ.get("APPRISE_API_ONLY", "no")[0].lower() in (
-    "a",
-    "y",
-    "1",
-    "t",
-    "e",
-    "+",
-)
+APPRISE_API_ONLY = parse_bool(os.environ.get("APPRISE_API_ONLY", "no"))
 
 # Allow Admin mode:
 # - showing a list of configuration keys (when STATEFUL_MODE is set to simple)
-APPRISE_ADMIN = os.environ.get("APPRISE_ADMIN", "no")[0].lower() in (
-    "a",
-    "y",
-    "1",
-    "t",
-    "e",
-    "+",
-)
+APPRISE_ADMIN = parse_bool(os.environ.get("APPRISE_ADMIN", "no"))
 
 # Allow Interpret Emojis override
 APPRISE_INTERPRET_EMOJIS = (
-    None
-    if "APPRISE_INTERPRET_EMOJIS" not in os.environ
-    else os.environ.get("APPRISE_INTERPRET_EMOJIS", "yes")[0].lower()
-    in (
-        "a",
-        "y",
-        "1",
-        "t",
-        "e",
-        "+",
-    )
+    None if "APPRISE_INTERPRET_EMOJIS" not in os.environ else parse_bool(os.environ.get("APPRISE_INTERPRET_EMOJIS"))
 )
 
 # Allow HTTP Redirects override
@@ -394,7 +380,7 @@ APPRISE_INTERPRET_EMOJIS = (
 # the underlying requests library.  Set APPRISE_HTTP_REDIRECTS=no to disable
 # redirect following globally across all plugins without touching individual
 # URLs.
-APPRISE_HTTP_REDIRECTS = os.environ.get("APPRISE_HTTP_REDIRECTS", "yes")[0].lower() in ("a", "y", "1", "t", "e", "+")
+APPRISE_HTTP_REDIRECTS = parse_bool(os.environ.get("APPRISE_HTTP_REDIRECTS", "yes"))
 
 # Allow a server-wide default input body format to be configured.
 # Formatting is entirely optional and unset (None) by default: content is

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -123,6 +123,9 @@ TEMPLATES = [
 
 _LOG_LEVEL = os.environ.get("LOG_LEVEL", "debug" if DEBUG else "info").upper()
 
+# Default notification log level when a request does not provide one.
+APPRISE_LOG_LEVEL = _LOG_LEVEL
+
 LOGGING = {
     "version": 1,
     # preserve loggers created by third-party libraries
@@ -131,7 +134,12 @@ LOGGING = {
         "standard": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"},
     },
     "handlers": {
-        "console": {"class": "logging.StreamHandler", "formatter": "standard"},
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+            # Keep console output at the configured global level.
+            "level": _LOG_LEVEL,
+        },
     },
     "loggers": {
         "django": {
@@ -142,7 +150,8 @@ LOGGING = {
         },
         "apprise": {
             "handlers": ["console"],
-            "level": _LOG_LEVEL,
+            # Allow request-specific capture before the console filters output.
+            "level": "TRACE",
             "propagate": False,
         },
     },

--- a/apprise_api/core/settings/__init__.py
+++ b/apprise_api/core/settings/__init__.py
@@ -26,7 +26,7 @@ import os
 
 import apprise
 from core.themes import SiteTheme
-from core.utils import parse_bool
+from core.utils import parse_bool, parse_log_level
 
 # Register apprise's custom log levels before Django's dictConfig() runs.
 if not hasattr(logging, "TRACE"):
@@ -115,7 +115,13 @@ TEMPLATES = [
     },
 ]
 
-_LOG_LEVEL = os.environ.get("LOG_LEVEL", "debug" if DEBUG else "info").upper()
+# Keep Django startup safe when LOG_LEVEL is empty or unsupported.
+_LOG_LEVEL = logging.getLevelName(
+    parse_log_level(
+        os.environ.get("LOG_LEVEL"),
+        "DEBUG" if DEBUG else "INFO",
+    )
+)
 
 # Default notification log level when a request does not provide one.
 APPRISE_LOG_LEVEL = _LOG_LEVEL

--- a/apprise_api/core/utils.py
+++ b/apprise_api/core/utils.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import logging
+
+# Keep accepted names and their logging values in one shared lookup.
+_LOG_LEVELS = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "TRACE": logging.DEBUG - 1,
+}
+
+# Existing query options accept these familiar truthy first characters.
+_TRUE_PREFIXES = frozenset(("a", "y", "1", "t", "e", "+"))
+
+
+def parse_bool(value, default=False):
+    """Parse a loose boolean from its first non-whitespace character."""
+    # A missing option should behave exactly like the caller's default.
+    if value is None:
+        return default
+
+    # Empty strings also fall back instead of causing an index error.
+    value = str(value).strip().lower()
+    return value[:1] in _TRUE_PREFIXES if value else default
+
+
+def parse_log_level(value, default="WARNING"):
+    """Return a supported log level, using the default for invalid values."""
+    # Normalize request values before comparing them with known names.
+    name = str(value).strip().upper()
+
+    if name not in _LOG_LEVELS:
+        # A bad configured default safely settles on WARNING below.
+        name = str(default).strip().upper()
+
+    # WARNING is the final safe choice when both supplied names are invalid.
+    return _LOG_LEVELS.get(name, logging.WARNING)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -109,6 +109,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/RecursionHeader'
         - $ref: '#/components/parameters/IdHeader'
+        - $ref: '#/components/parameters/StreamQueryParam'
       requestBody:
         required: true
         content:
@@ -124,7 +125,10 @@ paths:
       responses:
         '200':
           description: >
-            Notification accepted. Response contains processing logs.
+            Notification accepted. Completed processing logs are transferred
+            one entry at a time. When `stream` is truthy or
+            `Accept: text/event-stream` is sent, a live event stream reports
+            the same information as it happens.
           content:
             text/plain:
               schema:
@@ -137,6 +141,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LogResponse'
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/StreamEvent'
         '204':
           description: No Content (No valid URLs provided).
         '400':
@@ -306,6 +313,7 @@ paths:
         - $ref: '#/components/parameters/key'
         - $ref: '#/components/parameters/RecursionHeader'
         - $ref: '#/components/parameters/IdHeader'
+        - $ref: '#/components/parameters/StreamQueryParam'
       requestBody:
         required: false
         content:
@@ -320,7 +328,11 @@ paths:
               $ref: '#/components/schemas/PersistentNotificationForm'
       responses:
         '200':
-          description: Notification accepted. Response contains logs.
+          description: >
+            Notification accepted. Completed logs are transferred one entry
+            at a time. When `stream` is truthy or `Accept: text/event-stream` is
+            sent, a live event stream reports the same information as it
+            happens.
           content:
             text/plain:
               schema:
@@ -331,6 +343,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LogResponse'
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/StreamEvent'
         '204':
           description: No configuration found for this key.
         '406':
@@ -403,6 +418,18 @@ components:
       schema:
         type: string
       description: Optional Unique ID to associate with the notification.
+    StreamQueryParam:
+      in: query
+      name: stream
+      schema:
+        type: string
+        default: "no"
+      required: false
+      description: >
+        Values beginning with "y", "1", "t", "e", or "a" stream
+        notification progress; `%2B` is also accepted. This matches other
+        Apprise API boolean options and is equivalent to sending
+        `Accept: text/event-stream`.
 
   schemas:
     NotificationType:
@@ -474,6 +501,32 @@ components:
             type: array
             items:
               type: string
+
+    StreamEvent:
+      type: string
+      description: >
+        A Server-Sent Events response. Each event has an `event: <name>`
+        line, a `data: <json>` line, and a blank line. It contains zero or
+        more `log` events followed by one `result` or `error` event. Slow
+        clients keep 2 MB in memory and use up to 256 MB of automatically
+        cleaned temporary storage by default. A storage limit or failure does
+        not stop notification delivery; the stream reports it as an `ERROR`
+        log and continues when space is available:
+          - `log`: `{"level": string, "asctime": string, "message": string,
+            "service": string|null}` — one captured log line as it's
+            produced; `service` is the service *type* (e.g. "JSON",
+            "Telegram"), never a URL.
+          - `result`: `{"status": string}` — the final
+            AppriseResultStatus (e.g. "SUCCESS", "FAILURE", "NOMATCH",
+            "PARTIAL", "TIMEOUT") once every service has finished.
+          - `error`: `{"message": string}` — sent instead of `result` if
+            notification processing raised unexpectedly.
+      example: |
+        event: log
+        data: {"level": "INFO", "asctime": "2025-01-01 12:00:00,000", "message": "Sent to Telegram", "service": "Telegram"}
+
+        event: result
+        data: {"status": "SUCCESS"}
 
     # JSON Request
     StatelessNotificationRequest:


### PR DESCRIPTION
## Description
**Related issue (if applicable):** https://github.com/caronc/apprise/pull/1697

In support of Apprise v2.x.x; adapt to the new logging callback style
- Adds live notification progress using Server-Sent Events.
- Streams completed responses to reduce memory use for large logs.
- Adds `APPRISE_STREAM_MEMORY_SIZE` to control how much waiting log data remains in memory. The default is `2 MB`.
- Adds `APPRISE_STREAM_DISK_SIZE` to limit temporary disk storage for live streams and completed results. The default is `256 MB`.
- Moves waiting logs to temporary disk storage when the memory allowance is reached.
- Cleans up temporary files automatically after completion, disconnection, or process exit.
- Sends completion webhooks without loading the complete result into memory.
- Gracefully handles webhook timeouts, HTTP errors, storage failures, and cleanup errors.
- Shares consistent boolean and log-level parsing.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): https://github.com/caronc/apprise-docs/commit/8f6f76d2f5ed806b58bb23c642bdae8d90469b3a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b apprise-v2-log-enhancments https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000 using apprise v2 release
tox -e runserver -- --branch=apprise-v2-release

# or this branch if it hasn't been merged into the core v2 branch yet
tox -e runserver --  --branch=v2-further-log-refactoring
```
