### PR TITLE
Fixed :edge / :latest build + gevent error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=edge
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,3 +69,58 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml
         fail_ci_if_error: false
+
+  docker-smoke-test:
+    name: Docker Build/Start Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Acquire sources
+      uses: actions/checkout@v7
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    # Run a smoke-test on build to ensure it compiles and ships correctly
+    - name: Build Image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        load: true
+        push: false
+        tags: apprise-api:smoke-test
+
+    - name: Start container
+      run: |
+        docker run -d --name apprise-smoke -p 8000:8000 apprise-api:smoke-test
+
+    # Poll the status endpoint
+    #  - Tests: nginx -> gunicorn -> Django
+    #  - expect a 200 response
+    - name: Wait for a healthy response
+      # Wait up to 2 minutes before giving up
+      run: |
+        for i in $(seq 1 60); do
+          if ! docker ps -f name=apprise-smoke -f status=running | grep -q apprise-smoke; then
+            echo "Container exited early, Deployment Contains Issues."
+            exit 1
+          fi
+
+          if curl -sf http://localhost:8000/status; then
+            echo "Container is up and healthy."
+            exit 0
+          fi
+
+          sleep 2
+        done
+
+        echo "Timed out waiting for a healthy response."
+        exit 1
+
+    - name: Show container logs
+      if: always()
+      run: docker logs apprise-smoke
+
+    - name: Tear down container
+      if: always()
+      run: docker rm --force apprise-smoke

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "apprise == 1.12.0",
   "django",
   "gevent",
-  "gunicorn",
+  "gunicorn[gevent]",
   "requests",
   "paho-mqtt >= 2.1.0",
   "gntp",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ apprise == 1.12.0
 ## Apprise API Minimum Requirements
 django
 gevent
-gunicorn
+## newer gunicorn releases no longer pull it in as a base dependency
+gunicorn[gevent]
 
 ## for webhook support
 requests


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #352

- It turns out newer versions of gunicorn need a `gunicorn[gevent]` reference to work.  This is now fixed
- Fixed code that was causing `:latest` to align with `:edge`.  This was NEVER intended to be the case.  `:latest` should ALWAYS point to the last stable/tested branch.

Unfortunately those using `:latest` got `:edge` and then got the brand new `gunicorn` change breaking their environment.

Those users can safely resort back to using `:v1.5.1`,  But to fix this for good, i will create a `v1.5.2` all can use that will re-align `:latest` shortly.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b 352-packaging-github-issue https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
