### PR TITLE
fixed API config display issue via web interface

### DIFF
--- a/apprise_api/api/tests/test_get.py
+++ b/apprise_api/api/tests/test_get.py
@@ -85,3 +85,36 @@ class GetTests(SimpleTestCase):
         # response
         assert "Content-Type" in response
         assert response["Content-Type"].startswith("text/yaml")
+
+    def test_get_config_json_content_type_without_explicit_accept(self):
+        """
+        A browser fetch() call typically sends an explicit JSON
+        Content-Type but leaves Accept at its default of */*. That must
+        still be honored as a request for a JSON response (this is what
+        the web UI's config tab relies on to load existing configuration).
+        """
+
+        key = "test_get_config_json_"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/get/{}".format(key),
+            content_type="application/json",
+            HTTP_ACCEPT="*/*",
+        )
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("application/json")
+        payload = response.json()
+        assert "config" in payload
+        assert "format" in payload
+
+        # An Accept that explicitly asks for something else still wins
+        # over the JSON Content-Type
+        response = self.client.post(
+            "/get/{}".format(key),
+            content_type="application/json",
+            HTTP_ACCEPT="text/plain",
+        )
+        assert response.status_code == 200
+        assert not response["Content-Type"].startswith("application/json")

--- a/apprise_api/api/tests/test_manager.py
+++ b/apprise_api/api/tests/test_manager.py
@@ -137,6 +137,29 @@ class ManagerPageTests(SimpleTestCase):
         assert "Content-Type" in response
         assert response["Content-Type"].startswith("text/yaml")
 
+    def test_get_config_json_content_type_without_explicit_accept(self):
+        """
+        The web UI's config tab loads existing configuration via a
+        fetch() call carrying an explicit JSON Content-Type but no
+        Accept override (so Accept defaults to */*). That must still be
+        honored as a request for a JSON response.
+        """
+
+        key = "test_cfg_config_json_"
+        response = self.client.post("/add/{}".format(key), {"urls": "mailto://user:pass@yahoo.ca"})
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/cfg/{}".format(key),
+            content_type="application/json",
+            HTTP_ACCEPT="*/*",
+        )
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("application/json")
+        payload = response.json()
+        assert "config" in payload
+        assert "format" in payload
+
     def test_manage_cfg_list_content_type_defaults_to_html(self):
         """
         /cfg/ should render HTML by default when allowed.

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -39,6 +39,7 @@ import tempfile
 
 import apprise
 from django.conf import settings
+from django.http import HttpRequest
 import requests
 
 from .urlfilter import AppriseURLFilter
@@ -52,6 +53,24 @@ logger = logging.getLogger("django")
 # application/json
 # application/x-json
 MIME_IS_JSON = re.compile(r"(text|application)/(x-)?json", re.I)
+
+# Parsing of Accept; the following amounts to Accept All
+# */*
+# <blank>
+ACCEPT_ALL = re.compile(r"^\s*([*]/[*]|)\s*$", re.I)
+
+
+def is_json_response(request: HttpRequest) -> bool:
+    """Return whether the request prefers a JSON response.
+
+    Accept takes priority. Missing or wildcard Accept falls back to the
+    request Content-Type for backward compatibility.
+    """
+    accept = request.headers.get("accept", "")
+    content_type = request.content_type or request.headers.get("content-type", "")
+    return MIME_IS_JSON.match(accept) is not None or (
+        ACCEPT_ALL.match(accept) is not None and MIME_IS_JSON.match(content_type) is not None
+    )
 
 
 class AppriseStoreMode:

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -54,6 +54,7 @@ from .utils import (
     ConfigCache,
     apply_global_filters,
     healthcheck,
+    is_json_response,
     parse_attachments,
     send_webhook,
 )
@@ -65,12 +66,6 @@ logger = logging.getLogger("django")
 # application/x-www-form-urlencoded
 # multipart/form-data
 MIME_IS_FORM = re.compile(r"(multipart|application)/(x-www-)?form-(data|urlencoded)", re.I)
-
-
-# Parsing of Accept; the following amounts to Accept All
-# */*
-# <blank>
-ACCEPT_ALL = re.compile(r"^\s*([*]/[*]|)\s*$", re.I)
 
 # Tags separated by space, &, or + are and'ed together
 # Tags separated by commas (even commas wrapped in spaces) are "or'ed" together
@@ -230,12 +225,7 @@ def _get_config_response(request, key):
     """
 
     # Detect the format our response should be in.
-    json_response = (
-        MIME_IS_JSON.match(
-            request.headers.get("accept") or request.content_type or request.headers.get("content-type", "")
-        )
-        is not None
-    )
+    json_response = is_json_response(request)
 
     if settings.APPRISE_CONFIG_LOCK:
         # General Access Control
@@ -371,20 +361,8 @@ class HealthCheckView(View):
         """
         Handle a GET request
         """
-        # Detect the format our incoming payload
-        json_payload = (
-            MIME_IS_JSON.match(
-                request.content_type if request.content_type else request.headers.get("content-type", "")
-            )
-            is not None
-        )
-
         # Detect the format our response should be in
-        json_response = (
-            True
-            if json_payload and ACCEPT_ALL.match(request.headers.get("accept", ""))
-            else MIME_IS_JSON.match(request.headers.get("accept", "")) is not None
-        )
+        json_response = is_json_response(request)
 
         # Run our healthcheck; allow ?force which will cause the check to run each time
         response = healthcheck(lazy="force" not in request.GET)
@@ -427,12 +405,7 @@ class DetailsView(View):
         """
 
         # Detect the format our response should be in.
-        json_response = (
-            MIME_IS_JSON.match(
-                request.headers.get("accept") or request.content_type or request.headers.get("content-type", "")
-            )
-            is not None
-        )
+        json_response = is_json_response(request)
 
         if settings.APPRISE_API_ONLY and not json_response:
             # API Mode only disables the browsable HTML page.
@@ -531,23 +504,10 @@ class ConfigListView(View):
         """
         Handle a GET request
         """
-        # Detect the format our response should be in.
-        #
-        # This must check Accept first: Content-Type describes the
-        # *request* body, not the desired response, and a bodyless
-        # GET/POST still gets a Content-Type from the WSGI layer (commonly
-        # "text/plain" per the WSGI/CGI convention for an omitted
-        # Content-Type) even when the client never sent one - so checking
-        # it before Accept silently ignores an explicit
-        # "Accept: application/json" whenever there's no real request
-        # body, which is the common case for a JSON API client fetching
-        # data with a plain GET.
-        json_response = (
-            MIME_IS_JSON.match(
-                request.headers.get("accept") or request.content_type or request.headers.get("content-type", "")
-            )
-            is not None
-        )
+        # Detect the format our response should be in. An explicit Accept
+        # wins; a missing/wildcard Accept falls back to Content-Type so a
+        # JSON API client on a bodyless GET still gets a JSON reply.
+        json_response = is_json_response(request)
 
         if settings.APPRISE_API_ONLY and not json_response:
             # API Mode only disables the browsable HTML page; a JSON API
@@ -611,11 +571,7 @@ class AddView(View):
         )
 
         # Detect the format our response should be in
-        json_response = (
-            True
-            if json_payload and ACCEPT_ALL.match(request.headers.get("accept", ""))
-            else MIME_IS_JSON.match(request.headers.get("accept", "")) is not None
-        )
+        json_response = is_json_response(request)
 
         if settings.APPRISE_CONFIG_LOCK:
             # General Access Control
@@ -964,23 +920,10 @@ class DelView(View):
         """
         Handle a POST request
         """
-        # Detect the format our response should be in.
-        #
-        # This must check Accept first: Content-Type describes the
-        # *request* body, not the desired response, and a bodyless
-        # GET/POST still gets a Content-Type from the WSGI layer (commonly
-        # "text/plain" per the WSGI/CGI convention for an omitted
-        # Content-Type) even when the client never sent one - so checking
-        # it before Accept silently ignores an explicit
-        # "Accept: application/json" whenever there's no real request
-        # body, which is the common case for a JSON API client fetching
-        # data with a plain GET.
-        json_response = (
-            MIME_IS_JSON.match(
-                request.headers.get("accept") or request.content_type or request.headers.get("content-type", "")
-            )
-            is not None
-        )
+        # Detect the format our response should be in. An explicit Accept
+        # wins; a missing/wildcard Accept falls back to Content-Type so a
+        # JSON API client on a bodyless GET still gets a JSON reply.
+        json_response = is_json_response(request)
 
         if settings.APPRISE_CONFIG_LOCK:
             # General Access Control
@@ -1104,11 +1047,7 @@ class NotifyView(View):
         )
 
         # Detect the format our response should be in
-        json_response = (
-            True
-            if json_payload and ACCEPT_ALL.match(request.headers.get("accept", ""))
-            else MIME_IS_JSON.match(request.headers.get("accept", "")) is not None
-        )
+        json_response = is_json_response(request)
 
         # rules
         rules = {k[1:]: v for k, v in request.GET.items() if k[0] == ":"}
@@ -1800,11 +1739,7 @@ class StatelessNotifyView(View):
         )
 
         # Detect the format our response should be in
-        json_response = (
-            True
-            if json_payload and ACCEPT_ALL.match(request.headers.get("accept", ""))
-            else MIME_IS_JSON.match(request.headers.get("accept", "")) is not None
-        )
+        json_response = is_json_response(request)
 
         # rules
         rules = {k[1:]: v for k, v in request.GET.items() if k[0] == ":"}


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #351

Fixed issue with Configuration Information not showing on webpage; this was a regression error from backporting some features coming in Apprise v2 back to v1

## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e test`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Clone the branch
git clone -b 351-accept-content-type-fix https://github.com/caronc/apprise-api.git
cd apprise-api

# Run the unit tests
tox -e test

# Run a local instance of the api at http://localhost:8000
tox -e runserver
```
