### PR TITLE
Support environment variables in locked mounted configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,63 @@ services:
       - ./attach:/attach
 ```
 
+### Environment Variables in Mounted Configurations
+
+Administrator-managed configuration files can use `${NAME}` placeholders for
+credentials supplied through the container environment. Enable both
+`APPRISE_STATEFUL_MODE=simple` and `APPRISE_CONFIG_LOCK=yes`. The lock disables
+configuration uploads, edits, deletion, and exports through the API and web UI;
+notifications and the credential-masked URL list remain available.
+
+For example, keep this in `./config/apprise.cfg`:
+
+```text
+notifications = tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890
+```
+
+Supply the token separately in an untracked `apprise.env` file:
+
+```dotenv
+TELEGRAM_BOT_TOKEN=your-token
+```
+
+Add these settings to your Compose service:
+
+```yaml
+services:
+  apprise:
+    environment:
+      APPRISE_STATEFUL_MODE: simple
+      APPRISE_CONFIG_LOCK: "yes"
+    env_file:
+      - ./apprise.env
+    volumes:
+      - ./config:/config
+```
+
+Send a notification using the filename as the key:
+
+```bash
+curl http://localhost:8000/notify/apprise \
+  --data-urlencode 'body=Test notification' \
+  --data-urlencode 'tag=notifications'
+```
+
+The same substitution works in YAML URLs and URL option values in `apprise.yml`.
+Files retain their placeholders, so protocols, tags, and destination IDs can be
+backed up without the token. Recreate the container after updating `apprise.env`
+to supply the new environment. Missing or empty variables reject the configuration;
+use `$${NAME}` for a literal placeholder. Values used inside URLs require normal
+URL percent-encoding.
+
+Only administrator-managed files in locked, simple storage use this feature.
+Review existing configurations before enabling it. Uploaded configurations in
+unlocked storage, hash storage, stateless notification URLs, and remotely included
+configurations retain literal values. Locked files follow Apprise's local-file
+include rules and the configured recursion limit.
+
+### Production Compose Settings
+
 For production deployments, do not use `docker-compose.override.yml`.
 Deploy using only `docker-compose.yml`, so the container uses the immutable image and its bundled static assets.
 ```bash

--- a/apprise_api/api/tests/test_config_environment.py
+++ b/apprise_api/api/tests/test_config_environment.py
@@ -1,0 +1,138 @@
+# Copyright (C) 2026 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import json
+from unittest import mock
+
+from api import views
+from api.utils import AppriseConfigCache, AppriseStoreMode
+import apprise
+import pytest
+
+
+@pytest.fixture
+def local_config(tmp_path, monkeypatch, settings):
+    settings.APPRISE_CONFIG_LOCK = True
+    cache = AppriseConfigCache(str(tmp_path), mode=AppriseStoreMode.SIMPLE)
+    monkeypatch.setattr(views, "ConfigCache", cache)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test_token")
+    return cache
+
+
+@pytest.mark.parametrize(
+    ("extension", "content"),
+    [
+        ("cfg", "notifications = tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890"),
+        ("yml", "urls:\n  - tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890:\n      tag: notifications\n"),
+    ],
+)
+def test_notify_mounted_config(client, local_config, tmp_path, monkeypatch, extension, content):
+    """A mounted template delivers through the API without rewriting credentials to disk."""
+    path = tmp_path / f"apprise.{extension}"
+    path.write_text(content, encoding="utf-8")
+
+    with mock.patch("apprise.plugins.telegram.requests.post") as post:
+        post.return_value.status_code = 200
+        for token in ("test_token", "rotated_token"):
+            monkeypatch.setenv("TELEGRAM_BOT_TOKEN", token)
+            response = client.post("/notify/apprise", {"body": "test notification", "tag": "notifications"})
+            assert response.status_code == 200
+            post.assert_called_once()
+            assert post.call_args.args[0] == f"https://api.telegram.org/bot123456789:{token}/sendMessage"
+            payload = json.loads(post.call_args.kwargs["data"])
+            assert str(payload["chat_id"]) == "-1001234567890"
+            assert payload["text"] == "test notification"
+            assert path.read_text(encoding="utf-8") == content
+            post.reset_mock()
+
+        response = client.post("/notify/apprise", {"body": "test notification", "tag": "other"})
+        assert response.status_code == 424
+        post.assert_not_called()
+
+
+def test_missing_environment_prevents_delivery(client, local_config, tmp_path, monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN")
+    (tmp_path / "apprise.cfg").write_text(
+        "tgram://123456789:literal_token/-1001234567890\ntgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890\n",
+        encoding="utf-8",
+    )
+    with mock.patch("apprise.plugins.telegram.requests.post") as post:
+        assert client.post("/notify/apprise", {"body": "test"}).status_code == 424
+        post.assert_not_called()
+
+
+def test_locked_config_endpoints(client, local_config, tmp_path):
+    content = "notifications = tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890"
+    path = tmp_path / "apprise.cfg"
+    path.write_text(content, encoding="utf-8")
+    for endpoint in ("add", "del", "get", "cfg"):
+        assert client.post(f"/{endpoint}/apprise", {"config": "json://example.com"}).status_code == 403
+
+    response = client.get("/json/urls/apprise?privacy=no")
+    assert response.status_code == 200
+    assert response.json()["tags"] == ["notifications"]
+    assert len(response.json()["urls"]) == 1
+    assert b"test_token" not in response.content
+    assert b"TELEGRAM_BOT_TOKEN" not in response.content
+    assert path.read_text(encoding="utf-8") == content
+
+
+@pytest.mark.parametrize(("mode", "locked"), [("simple", False), ("hash", False), ("hash", True)])
+def test_other_storage_remains_literal(client, tmp_path, monkeypatch, settings, mode, locked):
+    settings.APPRISE_CONFIG_LOCK = locked
+    monkeypatch.setenv("APPRISE_TEST_PATH", "resolved")
+    cache = AppriseConfigCache(str(tmp_path), mode=mode)
+    monkeypatch.setattr(views, "ConfigCache", cache)
+    content = "json://example.com/${APPRISE_TEST_PATH}"
+    if not locked:
+        response = client.post("/add/apprise", {"config": content, "format": "text"})
+        assert response.status_code == 200
+    else:
+        assert cache.put("apprise", content, "text")
+
+    with mock.patch("apprise.plugins.custom_json.requests.request") as post:
+        post.return_value.status_code = 200
+        assert client.post("/notify/apprise", {"body": "test"}).status_code == 200
+        post.assert_called_once()
+        assert "resolved" not in post.call_args.args[1]
+        assert "APPRISE_TEST_PATH" in post.call_args.args[1]
+
+
+def test_stateless_urls_remain_literal(client, local_config, monkeypatch):
+    monkeypatch.setenv("APPRISE_TEST_PATH", "resolved")
+    with mock.patch("apprise.plugins.custom_json.requests.request") as post:
+        post.return_value.status_code = 200
+        response = client.post("/notify", {"urls": "json://example.com/${APPRISE_TEST_PATH}", "body": "test"})
+        assert response.status_code == 200
+        post.assert_called_once()
+        assert "resolved" not in post.call_args.args[1]
+        assert "APPRISE_TEST_PATH" in post.call_args.args[1]
+
+
+def test_large_local_config_preserves_asset(local_config, tmp_path):
+    content = "# comment\n" * 20000 + "json://example.com"
+    (tmp_path / "apprise.cfg").write_text(content, encoding="utf-8")
+    asset = apprise.AppriseAsset(app_id="Mounted config test")
+    config = local_config.load("apprise", content, "text", asset=asset)
+    servers = config.servers()
+    assert len(servers) == 1
+    assert servers[0].asset is asset

--- a/apprise_api/api/utils.py
+++ b/apprise_api/api/utils.py
@@ -38,6 +38,7 @@ import shutil
 import tempfile
 
 import apprise
+from apprise.config.file import ConfigFile
 from django.conf import settings
 from django.http import HttpRequest
 import requests
@@ -698,6 +699,24 @@ class AppriseConfigCache:
 
         # return our read content
         return (content, fmt)
+
+    def load(self, key, content, fmt, asset=None):
+        """Load a saved configuration, trusting locked simple files as local sources."""
+        config = apprise.AppriseConfig(asset=asset, recursion=settings.APPRISE_RECURSION_MAX)
+        if settings.APPRISE_CONFIG_LOCK and self.mode == AppriseStoreMode.SIMPLE:
+            path, filename = self.path(key)
+            source = ConfigFile(
+                path=os.path.join(path, "{}.{}".format(filename, SIMPLE_FILE_EXTENSION_MAPPING[fmt])),
+                format=fmt,
+                asset=asset,
+                recursion=settings.APPRISE_RECURSION_MAX,
+            )
+            # Preserve the cache reader's support for administrator-provided files of any size.
+            source.max_buffer_size = 0
+            config.add(source)
+        else:
+            config.add_config(content, format=fmt)
+        return config
 
     def clear(self, key, formats=None):
         """

--- a/apprise_api/api/views.py
+++ b/apprise_api/api/views.py
@@ -1528,10 +1528,7 @@ class NotifyView(View):
         a_obj = apprise.Apprise(asset=asset)
 
         # Create an apprise config object
-        ac_obj = apprise.AppriseConfig(asset=asset, recursion=settings.APPRISE_RECURSION_MAX)
-
-        # Load our configuration
-        ac_obj.add_config(config, format=format)
+        ac_obj = ConfigCache.load(key, config, format, asset=asset)
 
         # Add our configuration
         a_obj.add(ac_obj)
@@ -2439,10 +2436,7 @@ class JsonUrlView(View):
         a_obj = apprise.Apprise()
 
         # Create an apprise config object
-        ac_obj = apprise.AppriseConfig(recursion=settings.APPRISE_RECURSION_MAX)
-
-        # Load our configuration
-        ac_obj.add_config(config, format=format)
+        ac_obj = ConfigCache.load(key, config, format)
 
         # Add our configuration
         a_obj.add(ac_obj)


### PR DESCRIPTION
## Description

**Related issue (if applicable):** None.

Mounted configurations currently pass through `add_config()` as raw content, so they cannot use the Apprise library's local-file environment substitution. With `APPRISE_STATEFUL_MODE=simple` and `APPRISE_CONFIG_LOCK=yes`, load saved configurations through `ConfigFile` for both stateful notifications and URL listings.

For example, `/config/apprise.cfg` can contain:

```text
notifications = tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890
```

An operator supplies `TELEGRAM_BOT_TOKEN` through the container environment and posts to `/notify/apprise` with `tag=notifications`. The file retains the template so protocols, tags, and chat IDs can be backed up separately from credentials. TEXT and YAML configurations are supported.

The existing configuration lock disables configuration uploads, changes, deletion, and exports, and forces credential masking in URL listings. Unlocked simple storage, hash storage, and stateless notification URLs keep their existing raw-content behavior. Locked simple files follow the library's local-file include rules. The existing recursion limit, notification asset, and support for large administrator-provided files are preserved.

Environment substitution depends on caronc/apprise#1727. This draft was tested against that branch; the maintainer will need to coordinate the library dependency before merging. No fork dependency or speculative version bump is added to the project.

## Checklist

- [x] Documentation ticket created (if applicable): setup and Compose examples are included in this PR's README update.
- [x] The change is tested and works locally.
- [x] No commented-out code in this PR.
- [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
- [x] Test coverage added or updated (use `tox -e test`).

## Testing

- Full API test suite against the companion library branch: **163 passed**, **100% reported coverage**.
- Nine new tests exercise TEXT/YAML delivery through the actual notification API with mocked outbound HTTP, token changes between requests, unchanged template files, tag selection, missing variables, locked endpoints, masked URL listings, literal uploaded/stateless configurations, hash storage, and large files with a custom asset.
- Ruff lint and formatting: passed.
- `python -m openapi_spec_validator swagger.yaml`: passed.
- `git diff --check`: passed.

To reproduce with the companion library branch before its release:

```bash
git clone -b feature/local-config-environment https://github.com/dougmaitelli/apprise-api.git
cd apprise-api
python3 -m venv .venv
. .venv/bin/activate
pip install '.[dev]' 'apprise @ git+https://github.com/dougmaitelli/apprise.git@feature/config-environment-variables'
pytest --tb=short -q apprise_api
tox -e lint
```

The README includes the mounted configuration, separate environment file, Compose settings, and notification request for manual testing.
